### PR TITLE
Add CI CD Workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a bug report for the eBikes Africa assignments service.
+title: "[DATE]: [BUG]"
+labels: bug
+assignees: ''
+
+---
+
+## Description
+
+Please provide a detailed description of the issue. Include what you expected to happen and what actually happened.
+
+## Steps to Reproduce
+
+List the steps needed to reproduce the issue:
+
+1. Start the assignments service.
+2. Send a request to the relevant endpoint.
+3. Observe the unexpected response or behaviour.
+
+## Environment
+
+- OS: [e.g., Ubuntu 24.04]
+- Java Version: [e.g., 21]
+- PostgreSQL Version: [e.g., 16]
+
+## Possible Solution
+
+If you have suggestions on a fix or the cause of the issue, please describe them here.
+
+## Additional Context
+
+Add any other context about the problem here, such as error stack traces or logs.
+
+## Logs
+
+Include relevant logs or console outputs, especially those related to Spring Boot, PostgreSQL, Redis, or messaging.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Suggest an idea for the eBikes Africa assignments service.
+title: '[DATE]: [FEATURE REQUEST]'
+labels: feature
+assignees: ''
+
+---
+
+## Feature Description
+
+Please provide a concise and clear description of the feature you propose. Explain the value it will add or the problem
+it will solve.
+
+## Motivation
+
+Why is this feature important? Describe the need in the context of the assignments service.
+
+## Feature Details
+
+Provide a detailed explanation of what the feature should do:
+
+- Specific functionalities (e.g., new API endpoints, pricing logic changes).
+- Any changes to existing services, repositories, or Liquibase migrations.
+
+## Alternatives Considered
+
+Describe any alternative solutions considered and why they were rejected.
+
+## Potential Impact
+
+Discuss the potential impact of this feature, including:
+
+- Changes to the database schema and any required Liquibase migrations.
+- Compatibility with current Spring Boot configurations and messaging contracts.
+- Possible performance considerations.
+
+## Additional Context
+
+Add any other context, diagrams, or API contract documentation that would help in understanding or implementing this
+feature.

--- a/.github/ISSUE_TEMPLATE/REFACTOR_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/REFACTOR_REQUEST.md
@@ -1,0 +1,44 @@
+---
+name: Refactor request
+about: Suggest reorganization of the eBikes Africa assignments service codebase.
+title: "[DATE]: [REFACTOR]"
+labels: refactor
+assignees: ''
+
+---
+
+## Description
+
+Please provide a clear and concise description of the refactoring changes you propose and why they are necessary.
+
+## Related Files
+
+List the files affected by this refactor:
+
+- ExampleService.java
+- ExampleRepository.java
+
+## Changes
+
+Detail the main changes in bullet points:
+
+- Refactored ExampleService to reduce method complexity.
+- Optimised query generation in ExampleRepository.
+
+## Impact
+
+Describe the potential impact of this refactor:
+
+- Improved code maintainability and readability.
+- Potential impact on existing unit or integration tests.
+
+## Testing
+
+Outline the steps taken to test the refactor:
+
+- Unit tests updated and passing.
+- Integration tests verified against PostgreSQL and Redis.
+
+## Additional Notes
+
+Include any other information helpful for the reviewer, such as impacts on Liquibase migrations or messaging contracts.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Purpose
+
+Briefly describe the purpose of this pull request. What feature does it add or what issue does it address within the
+Spring Boot backend application?
+
+## List of Changes
+
+Explain your changes in detail:
+
+- Implemented a new service layer for managing database transactions.
+- Refactored the controller to handle new API endpoints for user authentication.
+
+## Linked Issues
+
+Mention any related issues here (if applicable):
+
+- Fixes #123
+- Related to #456
+
+## How to Test
+
+Provide instructions on how to test the new changes:
+
+1. Update your local MySQL database schema to match the latest changes in `schema.sql`.
+2. Run the Spring Boot application with `mvn spring-boot:run`.
+3. Use Postman to send a GET request to `localhost:8093/ebikes-assignments/`.
+
+## Additional Information
+
+Mention any additional information or context that would help in the review of this PR, such as database migrations or
+new environment variables.

--- a/.github/depandabot.yml
+++ b/.github/depandabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - staging
+      - main
+  pull_request:
+    branches:
+      - dev
+      - staging
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality-gate:
+    name: quality-gate
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build, test and analyse
+        run: |
+          ./mvnw verify -B \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} \
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }} \
+            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Set up Python for Semgrep
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.13'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep
+        run: semgrep --config auto --error
+
+      - name: Extract JAR layers
+        if: github.event_name == 'push'
+        run: |
+          set -Eeuo pipefail
+          java -Djarmode=layertools -jar target/*.jar extract --destination extracted/
+
+      - name: Prepare Docker build context artifact
+        if: github.event_name == 'push'
+        run: |
+          set -Eeuo pipefail
+
+          rm -rf docker-build-context
+          mkdir -p docker-build-context
+
+          test -f Dockerfile
+          test -d extracted/application
+          test -d extracted/dependencies
+          test -d extracted/spring-boot-loader
+
+          cp Dockerfile docker-build-context/
+          cp -R extracted/application docker-build-context/
+          cp -R extracted/dependencies docker-build-context/
+          cp -R extracted/spring-boot-loader docker-build-context/
+
+          if [ -d extracted/snapshot-dependencies ]; then
+            cp -R extracted/snapshot-dependencies docker-build-context/
+          fi
+
+          find docker-build-context -maxdepth 2 | sort
+
+      - name: Upload Docker build context
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: docker-build-context-${{ github.sha }}
+          path: docker-build-context/
+          retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: false

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,192 @@
+name: Publish Dev
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+concurrency:
+  group: publish-dev-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  publish-dev:
+    name: publish-dev
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'dev' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    environment:
+      name: dev
+
+    env:
+      IMAGE_REPOSITORY: ebikes/organizatons
+
+    steps:
+      - name: Derive image coordinates
+        id: image
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          FULL_SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${FULL_SHA:0:12}"
+          BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=sha-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Download Docker build context artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: docker-build-context-${{ github.event.workflow_run.head_sha }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: image-context/
+
+      - name: Validate Docker build context
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          test -d image-context
+          test -f image-context/Dockerfile
+          test -d image-context/application
+          test -d image-context/dependencies
+          test -d image-context/spring-boot-loader
+
+          if find image-context -type l | grep -q .; then
+            echo "Symlinks are not allowed in the Docker build context"
+            find image-context -type l -print
+            exit 1
+          fi
+
+          if find image-context -mindepth 1 -maxdepth 3 \
+            ! -path 'image-context/Dockerfile' \
+            ! -path 'image-context/application' \
+            ! -path 'image-context/application/*' \
+            ! -path 'image-context/dependencies' \
+            ! -path 'image-context/dependencies/*' \
+            ! -path 'image-context/spring-boot-loader' \
+            ! -path 'image-context/spring-boot-loader/*' \
+            ! -path 'image-context/snapshot-dependencies' \
+            ! -path 'image-context/snapshot-dependencies/*' \
+            | grep -q .
+          then
+            echo "Unexpected files found in Docker build context"
+            find image-context -mindepth 1 -maxdepth 3 | sort
+            exit 1
+          fi
+
+          find image-context -maxdepth 2 | sort
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@006813a119ae0fdeb70ae00f16cda21ee6f2ff3d
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Build and push dev image
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./image-context
+          file: ./image-context/Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:dev
+            ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.sha_tag }}
+          build-args: |
+            VERSION=dev
+            BUILD_DATE=${{ steps.image.outputs.build_date }}
+            VCS_REF=${{ steps.image.outputs.full_sha }}
+          labels: |
+            org.opencontainers.image.title=eBikes Africa organizatons service
+            org.opencontainers.image.version=dev
+            org.opencontainers.image.created=${{ steps.image.outputs.build_date }}
+            org.opencontainers.image.revision=${{ steps.image.outputs.full_sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.ref.name=dev
+          cache-from: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-dev
+          cache-to: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-dev,mode=max
+
+      - name: Trigger organizatons deployment via SSM
+        id: deploy
+        shell: bash
+        env:
+          DEPLOYMENT_REFERENCE: ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}@${{ steps.build.outputs.digest }}
+          INSTANCE_ID: ${{ vars.DEPLOY_INSTANCE_ID }}
+          SHORT_SHA: ${{ steps.image.outputs.short_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          test -n "${INSTANCE_ID}"
+          test -n "${DEPLOYMENT_REFERENCE}"
+
+          COMMAND_ID="$(
+            aws ssm send-command \
+              --region "${{ vars.AWS_REGION }}" \
+              --instance-ids "${INSTANCE_ID}" \
+              --document-name "AWS-RunShellScript" \
+              --comment "Deploy organizatons sha-${SHORT_SHA}" \
+              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizatons ${DEPLOYMENT_REFERENCE}" \
+              --query 'Command.CommandId' \
+              --output text
+          )"
+
+          echo "command_id=${COMMAND_ID}" >> "$GITHUB_OUTPUT"
+
+          aws ssm wait command-executed \
+            --region "${{ vars.AWS_REGION }}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${INSTANCE_ID}"
+
+          STATUS="$(
+            aws ssm get-command-invocation \
+              --region "${{ vars.AWS_REGION }}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query 'Status' \
+              --output text
+          )"
+
+          echo "SSM command status: ${STATUS}"
+          test "${STATUS}" = "Success"
+
+      - name: Publish summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Dev Publish Summary"
+            echo
+            echo "- Branch: dev"
+            echo "- Commit: \`${{ steps.image.outputs.full_sha }}\`"
+            echo "- Mutable tag: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:dev\`"
+            echo "- Immutable tag: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.sha_tag }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Deployment reference: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}@${{ steps.build.outputs.digest }}\`"
+            echo "- SSM command id: \`${{ steps.deploy.outputs.command_id }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -30,7 +30,7 @@ jobs:
       name: dev
 
     env:
-      IMAGE_REPOSITORY: ebikes/organizatons
+      IMAGE_REPOSITORY: ebikes/organizations
 
     steps:
       - name: Derive image coordinates
@@ -123,7 +123,7 @@ jobs:
             BUILD_DATE=${{ steps.image.outputs.build_date }}
             VCS_REF=${{ steps.image.outputs.full_sha }}
           labels: |
-            org.opencontainers.image.title=eBikes Africa organizatons service
+            org.opencontainers.image.title=eBikes Africa organizations service
             org.opencontainers.image.version=dev
             org.opencontainers.image.created=${{ steps.image.outputs.build_date }}
             org.opencontainers.image.revision=${{ steps.image.outputs.full_sha }}
@@ -132,7 +132,7 @@ jobs:
           cache-from: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-dev
           cache-to: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-dev,mode=max
 
-      - name: Trigger organizatons deployment via SSM
+      - name: Trigger organizations deployment via SSM
         id: deploy
         shell: bash
         env:
@@ -150,8 +150,8 @@ jobs:
               --region "${{ vars.AWS_REGION }}" \
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
-              --comment "Deploy organizatons sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizatons ${DEPLOYMENT_REFERENCE}" \
+              --comment "Deploy organizations sha-${SHORT_SHA}" \
+              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizations ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -30,7 +30,7 @@ jobs:
       name: staging
 
     env:
-      IMAGE_REPOSITORY: ebikes/organizatons
+      IMAGE_REPOSITORY: ebikes/organizations
 
     steps:
       - name: Derive image coordinates
@@ -122,7 +122,7 @@ jobs:
             BUILD_DATE=${{ steps.image.outputs.build_date }}
             VCS_REF=${{ steps.image.outputs.full_sha }}
           labels: |
-            org.opencontainers.image.title=eBikes Africa organizatons service
+            org.opencontainers.image.title=eBikes Africa organizations service
             org.opencontainers.image.version=staging
             org.opencontainers.image.created=${{ steps.image.outputs.build_date }}
             org.opencontainers.image.revision=${{ steps.image.outputs.full_sha }}
@@ -131,7 +131,7 @@ jobs:
           cache-from: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-staging
           cache-to: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-staging,mode=max
 
-      - name: Trigger organizatons deployment via SSM
+      - name: Trigger organizations deployment via SSM
         id: deploy
         shell: bash
         env:
@@ -149,8 +149,8 @@ jobs:
               --region "${{ vars.AWS_REGION }}" \
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
-              --comment "Deploy organizatons sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizatons ${DEPLOYMENT_REFERENCE}" \
+              --comment "Deploy organizations sha-${SHORT_SHA}" \
+              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizations ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,191 @@
+name: Publish Staging
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+concurrency:
+  group: publish-staging-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  publish-staging:
+    name: publish-staging
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'staging' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    environment:
+      name: staging
+
+    env:
+      IMAGE_REPOSITORY: ebikes/organizatons
+
+    steps:
+      - name: Derive image coordinates
+        id: image
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          FULL_SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA="${FULL_SHA:0:12}"
+          BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=sha-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Download Docker build context artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: docker-build-context-${{ github.event.workflow_run.head_sha }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: image-context/
+
+      - name: Validate Docker build context
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          test -d image-context
+          test -f image-context/Dockerfile
+          test -d image-context/application
+          test -d image-context/dependencies
+          test -d image-context/spring-boot-loader
+
+          if find image-context -type l | grep -q .; then
+            echo "Symlinks are not allowed in the Docker build context"
+            find image-context -type l -print
+            exit 1
+          fi
+
+          if find image-context -mindepth 1 -maxdepth 3 \
+            ! -path 'image-context/Dockerfile' \
+            ! -path 'image-context/application' \
+            ! -path 'image-context/application/*' \
+            ! -path 'image-context/dependencies' \
+            ! -path 'image-context/dependencies/*' \
+            ! -path 'image-context/spring-boot-loader' \
+            ! -path 'image-context/spring-boot-loader/*' \
+            ! -path 'image-context/snapshot-dependencies' \
+            ! -path 'image-context/snapshot-dependencies/*' \
+            | grep -q .
+          then
+            echo "Unexpected files found in Docker build context"
+            find image-context -mindepth 1 -maxdepth 3 | sort
+            exit 1
+          fi
+
+          find image-context -maxdepth 2 | sort
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@006813a119ae0fdeb70ae00f16cda21ee6f2ff3d
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Build and push staging image
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./image-context
+          file: ./image-context/Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:staging
+          build-args: |
+            VERSION=staging
+            BUILD_DATE=${{ steps.image.outputs.build_date }}
+            VCS_REF=${{ steps.image.outputs.full_sha }}
+          labels: |
+            org.opencontainers.image.title=eBikes Africa organizatons service
+            org.opencontainers.image.version=staging
+            org.opencontainers.image.created=${{ steps.image.outputs.build_date }}
+            org.opencontainers.image.revision=${{ steps.image.outputs.full_sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.ref.name=staging
+          cache-from: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-staging
+          cache-to: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache-staging,mode=max
+
+      - name: Trigger organizatons deployment via SSM
+        id: deploy
+        shell: bash
+        env:
+          DEPLOYMENT_REFERENCE: ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}@${{ steps.build.outputs.digest }}
+          INSTANCE_ID: ${{ vars.DEPLOY_INSTANCE_ID }}
+          SHORT_SHA: ${{ steps.image.outputs.short_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          test -n "${INSTANCE_ID}"
+          test -n "${DEPLOYMENT_REFERENCE}"
+
+          COMMAND_ID="$(
+            aws ssm send-command \
+              --region "${{ vars.AWS_REGION }}" \
+              --instance-ids "${INSTANCE_ID}" \
+              --document-name "AWS-RunShellScript" \
+              --comment "Deploy organizatons sha-${SHORT_SHA}" \
+              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizatons ${DEPLOYMENT_REFERENCE}" \
+              --query 'Command.CommandId' \
+              --output text
+          )"
+
+          echo "command_id=${COMMAND_ID}" >> "$GITHUB_OUTPUT"
+
+          aws ssm wait command-executed \
+            --region "${{ vars.AWS_REGION }}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${INSTANCE_ID}"
+
+          STATUS="$(
+            aws ssm get-command-invocation \
+              --region "${{ vars.AWS_REGION }}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query 'Status' \
+              --output text
+          )"
+
+          echo "SSM command status: ${STATUS}"
+          test "${STATUS}" = "Success"
+
+      - name: Publish summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Staging Publish Summary"
+            echo
+            echo "- Branch: staging"
+            echo "- Commit: \`${{ steps.image.outputs.full_sha }}\`"
+            echo "- Mutable tag: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:staging\`"
+            echo "- Immutable tag: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.sha_tag }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Deployment reference: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}@${{ steps.build.outputs.digest }}\`"
+            echo "- SSM command id: \`${{ steps.deploy.outputs.command_id }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,35 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-22.04
+    environment: release-please
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - name: Run Release Please
+        id: release
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release-type: maven
+          target-branch: main

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -24,7 +24,7 @@ jobs:
       name: production
 
     env:
-      IMAGE_REPOSITORY: ebikes/organizatons
+      IMAGE_REPOSITORY: ebikes/organizations
 
     steps:
       - name: Checkout Dockerfile
@@ -149,7 +149,7 @@ jobs:
             BUILD_DATE=${{ steps.image.outputs.build_date }}
             VCS_REF=${{ steps.image.outputs.full_sha }}
           labels: |
-            org.opencontainers.image.title=eBikes Africa organizatons service
+            org.opencontainers.image.title=eBikes Africa organizations service
             org.opencontainers.image.version=${{ steps.image.outputs.version }}
             org.opencontainers.image.created=${{ steps.image.outputs.build_date }}
             org.opencontainers.image.revision=${{ steps.image.outputs.full_sha }}
@@ -158,7 +158,7 @@ jobs:
           cache-from: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache
           cache-to: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache,mode=max
 
-      - name: Trigger organizatons deployment via SSM
+      - name: Trigger organizations deployment via SSM
         id: deploy
         shell: bash
         env:
@@ -176,8 +176,8 @@ jobs:
               --region "${{ vars.AWS_REGION }}" \
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
-              --comment "Deploy organizatons sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizatons ${DEPLOYMENT_REFERENCE}" \
+              --comment "Deploy organizations sha-${SHORT_SHA}" \
+              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizations ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -1,0 +1,218 @@
+name: Release Production
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+
+concurrency:
+  group: release-production-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-production:
+    name: release-production
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    environment:
+      name: production
+
+    env:
+      IMAGE_REPOSITORY: ebikes/organizatons
+
+    steps:
+      - name: Checkout Dockerfile
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            Dockerfile
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Derive image coordinates
+        id: image
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          VERSION="${{ github.event.release.tag_name }}"
+          FULL_SHA="${{ github.sha }}"
+          SHORT_SHA="${FULL_SHA:0:12}"
+          BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=sha-$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Find CI run for release SHA
+        id: ci-run
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              head_sha: context.sha,
+              status: 'success',
+              per_page: 1
+            });
+
+            if (runs.data.total_count === 0) {
+              core.setFailed(`No successful CI run found for SHA: ${context.sha}`);
+              return;
+            }
+
+            core.setOutput('run_id', runs.data.workflow_runs[0].id.toString());
+
+      - name: Download JAR layers
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: jar-layers-${{ github.sha }}
+          run-id: ${{ steps.ci-run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: extracted/
+
+      - name: Prepare Docker build context
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          rm -rf image-context
+          mkdir -p image-context
+
+          cp Dockerfile image-context/
+
+          if [ -d extracted/application ] && [ -d extracted/dependencies ] && [ -d extracted/spring-boot-loader ]; then
+            cp -R extracted/application image-context/
+            cp -R extracted/dependencies image-context/
+            cp -R extracted/spring-boot-loader image-context/
+            if find extracted -maxdepth 1 -type d -name 'snapshot-dependencies*' | grep -q .; then
+              find extracted -maxdepth 1 -type d -name 'snapshot-dependencies*' -exec cp -R {} image-context/ \;
+            fi
+          else
+            LAYER_ROOT="$(find extracted -mindepth 1 -maxdepth 2 -type d -name application | head -n1 | xargs -r dirname)"
+            if [ -z "${LAYER_ROOT:-}" ]; then
+              echo "Could not locate Spring Boot layer directories in extracted artifact"
+              find extracted -maxdepth 5 | sort
+              exit 1
+            fi
+
+            cp -R "$LAYER_ROOT/application" image-context/
+            cp -R "$LAYER_ROOT/dependencies" image-context/
+            cp -R "$LAYER_ROOT/spring-boot-loader" image-context/
+            if find "$LAYER_ROOT" -maxdepth 1 -type d -name 'snapshot-dependencies*' | grep -q .; then
+              find "$LAYER_ROOT" -maxdepth 1 -type d -name 'snapshot-dependencies*' -exec cp -R {} image-context/ \;
+            fi
+          fi
+
+          find image-context -maxdepth 2 -type d | sort
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@006813a119ae0fdeb70ae00f16cda21ee6f2ff3d
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        with:
+          driver-opts: network=host
+
+      - name: Build and push production image
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./image-context
+          file: ./image-context/Dockerfile
+          push: true
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.version }}
+          build-args: |
+            VERSION=${{ steps.image.outputs.version }}
+            BUILD_DATE=${{ steps.image.outputs.build_date }}
+            VCS_REF=${{ steps.image.outputs.full_sha }}
+          labels: |
+            org.opencontainers.image.title=eBikes Africa organizatons service
+            org.opencontainers.image.version=${{ steps.image.outputs.version }}
+            org.opencontainers.image.created=${{ steps.image.outputs.build_date }}
+            org.opencontainers.image.revision=${{ steps.image.outputs.full_sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.ref.name=${{ steps.image.outputs.version }}
+          cache-from: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache
+          cache-to: type=registry,ref=${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:buildcache,mode=max
+
+      - name: Trigger organizatons deployment via SSM
+        id: deploy
+        shell: bash
+        env:
+          DEPLOYMENT_REFERENCE: ${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}@${{ steps.build.outputs.digest }}
+          INSTANCE_ID: ${{ vars.DEPLOY_INSTANCE_ID }}
+          SHORT_SHA: ${{ steps.image.outputs.short_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          test -n "${INSTANCE_ID}"
+          test -n "${DEPLOYMENT_REFERENCE}"
+
+          COMMAND_ID="$(
+            aws ssm send-command \
+              --region "${{ vars.AWS_REGION }}" \
+              --instance-ids "${INSTANCE_ID}" \
+              --document-name "AWS-RunShellScript" \
+              --comment "Deploy organizatons sha-${SHORT_SHA}" \
+              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizatons ${DEPLOYMENT_REFERENCE}" \
+              --query 'Command.CommandId' \
+              --output text
+          )"
+
+          echo "command_id=${COMMAND_ID}" >> "$GITHUB_OUTPUT"
+
+          aws ssm wait command-executed \
+            --region "${{ vars.AWS_REGION }}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${INSTANCE_ID}"
+
+          STATUS="$(
+            aws ssm get-command-invocation \
+              --region "${{ vars.AWS_REGION }}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query 'Status' \
+              --output text
+          )"
+
+          echo "SSM command status: ${STATUS}"
+          test "${STATUS}" = "Success"
+
+      - name: Publish summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Production Release Summary"
+            echo
+            echo "- Version: \`${{ steps.image.outputs.version }}\`"
+            echo "- Commit: \`${{ steps.image.outputs.full_sha }}\`"
+            echo "- Release tag: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.version }}\`"
+            echo "- Immutable SHA tag: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}:${{ steps.image.outputs.sha_tag }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Deployment reference: \`${{ vars.ECR_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}@${{ steps.build.outputs.digest }}\`"
+            echo "- SSM command id: \`${{ steps.deploy.outputs.command_id }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/src/main/java/com/ebikes/organizations/database/models/DaySchedule.java
+++ b/src/main/java/com/ebikes/organizations/database/models/DaySchedule.java
@@ -30,5 +30,4 @@ public record DaySchedule(
     this.dayOfWeek = dayOfWeek;
     this.opens = opens;
   }
-
 }

--- a/src/main/java/com/ebikes/organizations/dtos/requests/branches/CreateBranchRequest.java
+++ b/src/main/java/com/ebikes/organizations/dtos/requests/branches/CreateBranchRequest.java
@@ -26,10 +26,7 @@ public record CreateBranchRequest(
     implements Serializable {
 
   public CreateBranchRequest {
-    operatingHours =
-        operatingHours != null
-            ? List.copyOf(operatingHours)
-            : List.of();
+    operatingHours = operatingHours != null ? List.copyOf(operatingHours) : List.of();
   }
 
   @Override


### PR DESCRIPTION
## Purpose

Introduce the CI/CD pipeline for the Organization service, enforcing a full quality gate and enabling automated image publishing and release management.

## List of Changes

* Added GitHub Actions workflows under `.github/workflows/`

  * `ci.yml` — quality gate (build, test, static analysis)
  * `publish-dev.yml` — build and push dev images to ECR
  * `publish-staging.yml` — build and push staging images to ECR
  * `release-please.yml` — automated release PR creation
  * `release-production.yml` — production image build from tags
* Added issue templates and PR template
* Integrated:

  * Checkstyle
  * SpotBugs
  * JaCoCo
  * Semgrep
  * SonarCloud
* Configured AWS authentication via OIDC (no static credentials)


## Linked Issues

* N/A


## How to Test

1. Push the branch and open a PR to `dev`
2. Verify CI workflow runs and passes:

   * Build (`mvn verify`)
   * Static analysis (Checkstyle, SpotBugs)
   * Coverage (JaCoCo)
   * Security scan (Semgrep)
   * SonarCloud analysis
3. Merge into `dev` and confirm:

   * Docker image is published to ECR with `dev` and `sha-*` tags
4. Promote to `staging` and confirm:

   * Image is published with `staging` and `sha-*` tags

## Additional Information

* CI enforces a strict quality gate — builds fail on any violations
* No workflows skip tests by design
* Release Please is the only versioning mechanism (no semantic-release)
* Production builds are triggered only from version tags
* No long-lived AWS credentials are used (OIDC only)
