### PR TITLE
Align organization configurations with platform standards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ SPRING_PROFILES_ACTIVE=local
 # server
 # =============================================================================
 SERVER_PORT=8087
+MANAGEMENT_SERVER_PORT=9087
 
 # =============================================================================
 # aws
@@ -28,39 +29,26 @@ AWS_S3_PREVIEW_URL_EXPIRY_MINUTES=5
 # =============================================================================
 # database
 # =============================================================================
-DATABASE_URL=jdbc:postgresql://localhost:5432/ebikes_organizations
-DATABASE_USER=postgres
-DATABASE_PASSWORD=<your-strong-password>
-DB_POOL_MAX=5
-DB_POOL_MIN_IDLE=1
-
-# =============================================================================
-# redis
-# =============================================================================
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_PASSWORD=<your-strong-password>
-REDIS_SSL_ENABLED=false
-
-# =============================================================================
-# cache
-# =============================================================================
-CACHE_TTL=3600000
+SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/ebikes_organizations
+SPRING_DATASOURCE_USERNAME=postgres
+SPRING_DATASOURCE_PASSWORD=<your-strong-password>
+SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE=5
+SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE=1
 
 # =============================================================================
 # rabbitmq
 # =============================================================================
-RABBITMQ_HOST=localhost
-RABBITMQ_PORT=5672
-RABBITMQ_USERNAME=admin
-RABBITMQ_PASSWORD=<your-strong-password>
+SPRING_RABBITMQ_HOST=localhost
+SPRING_RABBITMQ_PORT=5672
+SPRING_RABBITMQ_USERNAME=admin
+SPRING_RABBITMQ_PASSWORD=<your-strong-password>
 RABBITMQ_CONSUMER_GROUP=ebikes.organizations.incoming
 
 # =============================================================================
 # security
 # =============================================================================
-KEYCLOAK_ISSUER_URI=http://keycloak.localhost/realms/ebikes
-KEYCLOAK_JWK_SET_URI=http://keycloak.localhost/realms/ebikes/protocol/openid-connect/certs
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=http://keycloak.localhost/realms/ebikes
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://keycloak.localhost/realms/ebikes/protocol/openid-connect/certs
 
 # =============================================================================
 # javers
@@ -71,24 +59,3 @@ JAVERS_PRETTY_PRINT=false
 JAVERS_SPRING_DATA_AUDITABLE_REPOSITORY_ASPECT_ENABLED=false
 JAVERS_SQL_SCHEMA_MANAGEMENT_ENABLED=false
 JAVERS_TYPE_SAFE_VALUES=false
-
-# =============================================================================
-# liquibase
-# =============================================================================
-SPRING_LIQUIBASE_ENABLED=true
-
-# =============================================================================
-# hibernate
-# =============================================================================
-HIBERNATE_FORMAT_SQL=false
-HIBERNATE_SHOW_SQL=false
-
-# =============================================================================
-# actuator
-# =============================================================================
-ACTUATOR_HEALTH_DETAILS=always
-
-# =============================================================================
-# swagger
-# =============================================================================
-SWAGGER_ENABLED=true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
       bindings:
         incomingEventConsumer-in-0:
           destination: ebikes.domain-events
-          group: ${RABBITMQ_CONSUMER_GROUP}
+          group: ebikes.organizations.incoming
         eventPublisher-out-0:
           destination: ebikes.domain-events
       rabbit:
@@ -33,11 +33,10 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     hikari:
-      maximum-pool-size: ${DB_POOL_MAX}
-      minimum-idle: ${DB_POOL_MIN_IDLE}
-    password: ${DATABASE_PASSWORD}
-    url: ${DATABASE_URL}
-    username: ${DATABASE_USER}
+      maximum-pool-size: ${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE}
+      minimum-idle: ${SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
 
   jpa:
     hibernate:
@@ -46,28 +45,27 @@ spring:
     properties:
       hibernate:
         default_schema: organizations
-        format_sql: ${HIBERNATE_FORMAT_SQL}
-        show_sql: ${HIBERNATE_SHOW_SQL}
+        format_sql: false
+        show_sql: false
 
   liquibase:
     change-log: classpath:database/changelog/changelog-main.yaml
-    enabled: ${SPRING_LIQUIBASE_ENABLED}
+    enabled: true
     liquibase-schema: organizations
     parameters:
       searchPath: classpath:database/changelog
 
   rabbitmq:
-    host: ${RABBITMQ_HOST}
-    password: ${RABBITMQ_PASSWORD}
-    port: ${RABBITMQ_PORT}
-    username: ${RABBITMQ_USERNAME}
+    host: ${SPRING_RABBITMQ_HOST}
+    port: ${SPRING_RABBITMQ_PORT}
+    username: ${SPRING_RABBITMQ_USERNAME}
 
   security:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${KEYCLOAK_ISSUER_URI}
-          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI}
+          issuer-uri: ${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI}
+          jwk-set-uri: ${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI}
 
   web:
     resources:
@@ -112,7 +110,7 @@ logging:
 management:
   endpoint:
     health:
-      show-details: ${ACTUATOR_HEALTH_DETAILS:always}
+      show-details: never
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## Purpose

Aligns the organizations service configuration with the platform-wide convention established by the orders, workforce, and assignments services. Environment variable naming, secret targets, and `.env.example` are standardized across the stack.

## List of Changes

- `application.yaml` — renamed datasource, RabbitMQ, and security env vars to `SPRING_*` convention; hardcoded `format_sql`, `show_sql`, `liquibase.enabled`, and `management.health.show-details` to remove unnecessary env var surface
- `docker-stack.yml` — renamed all env vars to match; corrected secret targets to `spring.datasource.password` and `spring.rabbitmq.password` for `configtree` compatibility; renamed Swarm secrets to `organizations_spring_datasource_password` / `organizations_spring_rabbitmq_password`
- `organizations.sh` — renamed vars throughout `service_required_env_vars` and `service_prepare_env` to match; updated `service_secret_mappings` to reflect new secret names
- `.env.example` — renamed vars to platform convention; removed Redis, cache, liquibase, hibernate, actuator, and swagger entries

## Linked Issues

- Closes #
- Related to #

## How to Test

1. Copy `.env.example` to `.env` and fill in credentials
2. Start infrastructure with `docker compose up -d`
3. Run with `./mvnw spring-boot:run -Dspring-boot.run.profiles=local`
4. Confirm startup: `curl http://localhost:9087/actuator/health`

## Additional Information

The Swarm secrets `organizations_spring_datasource_password` and `organizations_spring_rabbitmq_password` must be created in the target environment before deploying. These map to the existing SSM keys `/ebikes/{env}/app/organizations.db.password` and `/ebikes/{env}/app/organizations.rabbitmq.password` respectively.