### PR TITLE
feat(organizations): add organization logo upload, confirmation, and retrieval

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -151,7 +151,7 @@ jobs:
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
               --comment "Deploy organizations sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizations ${DEPLOYMENT_REFERENCE}" \
+              --parameters commands="ebikes-deploy-backend deploy organizations ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -150,7 +150,7 @@ jobs:
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
               --comment "Deploy organizations sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizations ${DEPLOYMENT_REFERENCE}" \
+              --parameters commands="ebikes-deploy-backend deploy organizations ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -177,7 +177,7 @@ jobs:
               --instance-ids "${INSTANCE_ID}" \
               --document-name "AWS-RunShellScript" \
               --comment "Deploy organizations sha-${SHORT_SHA}" \
-              --parameters commands="/usr/local/bin/deploy-application.sh deploy organizations ${DEPLOYMENT_REFERENCE}" \
+              --parameters commands="ebikes-deploy-backend deploy organizations ${DEPLOYMENT_REFERENCE}" \
               --query 'Command.CommandId' \
               --output text
           )"

--- a/src/main/java/com/ebikes/organizations/controllers/OrganizationController.java
+++ b/src/main/java/com/ebikes/organizations/controllers/OrganizationController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,9 +22,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.internal.UploadUrlData;
 import com.ebikes.organizations.dtos.requests.filters.OrganizationFilter;
 import com.ebikes.organizations.dtos.requests.organizations.CreateOrganizationRequest;
 import com.ebikes.organizations.dtos.requests.organizations.DeactivateOrganizationRequest;
+import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
 import com.ebikes.organizations.dtos.requests.organizations.UpdateOrganizationRequest;
 import com.ebikes.organizations.dtos.responses.api.PaginatedResponse;
 import com.ebikes.organizations.dtos.responses.api.SuccessResponse;
@@ -34,6 +37,7 @@ import com.ebikes.organizations.dtos.responses.organizations.OrganizationRespons
 import com.ebikes.organizations.dtos.responses.organizations.OrganizationSummaryResponse;
 import com.ebikes.organizations.mappers.OrganizationMapper;
 import com.ebikes.organizations.services.documents.DocumentService;
+import com.ebikes.organizations.services.images.ImageService;
 import com.ebikes.organizations.services.organizations.OrganizationService;
 
 import lombok.RequiredArgsConstructor;
@@ -46,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrganizationController {
 
   private final DocumentService documentService;
+  private final ImageService imageService;
   private final OrganizationMapper organizationMapper;
   private final OrganizationService organizationService;
 
@@ -92,6 +97,33 @@ public class OrganizationController {
     List<DocumentSummaryResponse> documents =
         documentService.findByOrganization(id, includeInactive);
     return ResponseEntity.ok(SuccessResponse.of(documents));
+  }
+
+  @PreAuthorize("hasAnyAuthority('ORGANIZATION_ADMIN', 'SYSTEM_ADMIN')")
+  @PostMapping("/{id}/logo/upload-url")
+  public ResponseEntity<SuccessResponse<UploadUrlData>> generateLogoUploadUrl(
+      @PathVariable UUID id) {
+    UploadUrlData uploadUrlData = imageService.generateImageUploadUrl(id);
+    return ResponseEntity.ok(
+        SuccessResponse.of(uploadUrlData, "Logo upload URL generated successfully"));
+  }
+
+  @PreAuthorize("hasAnyAuthority('ORGANIZATION_ADMIN', 'SYSTEM_ADMIN')")
+  @PutMapping("/{id}/logo")
+  public ResponseEntity<Void> confirmLogoUpload(
+      @PathVariable UUID id, @Valid @RequestBody ImageUploadConfirmationRequest request) {
+    imageService.confirmImageUpload(id, request);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/{id}/logo")
+  public ResponseEntity<Void> getLogo(@PathVariable UUID id) {
+    String redirectUrl = imageService.generateImageRedirectUrl(id);
+    return ResponseEntity.status(HttpStatus.FOUND)
+        .header(HttpHeaders.LOCATION, redirectUrl)
+        .header(HttpHeaders.CACHE_CONTROL, "private, max-age=3600")
+        .build();
   }
 
   @GetMapping("/reference")

--- a/src/main/java/com/ebikes/organizations/database/entities/Organization.java
+++ b/src/main/java/com/ebikes/organizations/database/entities/Organization.java
@@ -83,6 +83,9 @@ public class Organization extends AuditableEntity implements Auditable {
   @Column(name = "legal_name", nullable = false)
   @NotBlank private String legalName;
 
+  @Column(name = "logo_key", length = 500)
+  private String logoKey;
+
   @Column(name = "owner_id", nullable = false, length = 36)
   @NotBlank private String ownerId;
 
@@ -132,10 +135,6 @@ public class Organization extends AuditableEntity implements Auditable {
     this.activatedAt = OffsetDateTime.now(ZoneOffset.UTC);
   }
 
-  void addDocument(Document document) {
-    this.documents.add(document);
-  }
-
   public void deactivate(String reason) {
     if (this.status != OrganizationStatus.ACTIVE) {
       throw new BusinessRuleException(
@@ -145,16 +144,6 @@ public class Organization extends AuditableEntity implements Auditable {
     this.status = OrganizationStatus.DEACTIVATED;
     this.deactivatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     this.rejectionReason = reason;
-  }
-
-  public void updateComplianceStatus(@NotNull ComplianceStatus complianceStatus) {
-    if (complianceStatus == ComplianceStatus.SUSPENDED) {
-      throw new BusinessRuleException(
-          ResponseCode.INVALID_STATE,
-          "Compliance suspension requires explicit admin action and cannot be set"
-              + " programmatically");
-    }
-    this.complianceStatus = complianceStatus;
   }
 
   public void reject(String reason) {
@@ -178,6 +167,20 @@ public class Organization extends AuditableEntity implements Auditable {
     this.rejectionReason = null;
   }
 
+  public void updateComplianceStatus(@NotNull ComplianceStatus complianceStatus) {
+    if (complianceStatus == ComplianceStatus.SUSPENDED) {
+      throw new BusinessRuleException(
+          ResponseCode.INVALID_STATE,
+          "Compliance suspension requires explicit admin action and cannot be set"
+              + " programmatically");
+    }
+    this.complianceStatus = complianceStatus;
+  }
+
+  public void updateLogoKey(String logoKey) {
+    this.logoKey = logoKey;
+  }
+
   @Override
   public Map<String, String> toAuditMetadata() {
     return Map.of(
@@ -186,5 +189,9 @@ public class Organization extends AuditableEntity implements Auditable {
         "ownerId", ownerId,
         "registrationType", registrationType.name(),
         "status", status.name());
+  }
+
+  void addDocument(Document document) {
+    this.documents.add(document);
   }
 }

--- a/src/main/java/com/ebikes/organizations/database/models/Address.java
+++ b/src/main/java/com/ebikes/organizations/database/models/Address.java
@@ -19,4 +19,13 @@ public record Address(
     @DecimalMin(value = "-180.0") @DecimalMax(value = "180.0") BigDecimal longitude,
     @Size(max = 20) String postalCode,
     @NotBlank @Size(max = 500) String streetAddress)
-    implements Serializable {}
+    implements Serializable {
+
+  public String toFormattedString() {
+    String base = streetAddress + ", " + city;
+    if (postalCode != null && !postalCode.isBlank()) {
+      base += ", " + postalCode;
+    }
+    return base + ", " + country;
+  }
+}

--- a/src/main/java/com/ebikes/organizations/database/repositories/BranchRepository.java
+++ b/src/main/java/com/ebikes/organizations/database/repositories/BranchRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.ebikes.organizations.database.entities.Branch;
-import com.ebikes.organizations.dtos.responses.branches.BranchReference;
 import com.ebikes.organizations.enums.BranchStatus;
 
 public interface BranchRepository
@@ -15,7 +14,7 @@ public interface BranchRepository
 
   boolean existsByOrganizationIdAndBranchNameIgnoreCase(UUID organizationId, String branchName);
 
-  List<BranchReference> findByIdInAndOrganizationId(List<UUID> ids, UUID organizationId);
+  List<Branch> findByIdInAndOrganizationId(List<UUID> ids, UUID organizationId);
 
   List<Branch> findByOrganizationId(UUID organizationId);
 

--- a/src/main/java/com/ebikes/organizations/database/repositories/OrganizationRepository.java
+++ b/src/main/java/com/ebikes/organizations/database/repositories/OrganizationRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import com.ebikes.organizations.database.entities.Organization;
-import com.ebikes.organizations.dtos.responses.organizations.OrganizationReference;
 
 @Repository
 public interface OrganizationRepository
@@ -16,5 +15,5 @@ public interface OrganizationRepository
 
   boolean existsByLegalName(String legalName);
 
-  List<OrganizationReference> findByIdIn(List<UUID> organizationIds);
+  List<Organization> findByIdIn(List<UUID> organizationIds);
 }

--- a/src/main/java/com/ebikes/organizations/dtos/requests/organizations/ImageUploadConfirmationRequest.java
+++ b/src/main/java/com/ebikes/organizations/dtos/requests/organizations/ImageUploadConfirmationRequest.java
@@ -1,0 +1,9 @@
+package com.ebikes.organizations.dtos.requests.organizations;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ImageUploadConfirmationRequest(
+    @NotNull @Min(value = 1) Long fileSizeBytes, @NotBlank @Size(max = 100) String mimeType) {}

--- a/src/main/java/com/ebikes/organizations/dtos/responses/branches/BranchReference.java
+++ b/src/main/java/com/ebikes/organizations/dtos/responses/branches/BranchReference.java
@@ -2,4 +2,4 @@ package com.ebikes.organizations.dtos.responses.branches;
 
 import java.util.UUID;
 
-public record BranchReference(UUID id, String displayName) {}
+public record BranchReference(UUID id, String displayName, String logoUrl) {}

--- a/src/main/java/com/ebikes/organizations/dtos/responses/organizations/OrganizationReference.java
+++ b/src/main/java/com/ebikes/organizations/dtos/responses/organizations/OrganizationReference.java
@@ -2,4 +2,4 @@ package com.ebikes.organizations.dtos.responses.organizations;
 
 import java.util.UUID;
 
-public record OrganizationReference(UUID id, String displayName) {}
+public record OrganizationReference(UUID id, String address, String displayName, String logoUrl) {}

--- a/src/main/java/com/ebikes/organizations/mappers/BranchMapper.java
+++ b/src/main/java/com/ebikes/organizations/mappers/BranchMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import com.ebikes.organizations.database.entities.Branch;
 import com.ebikes.organizations.dtos.responses.branches.BranchAddressResponse;
+import com.ebikes.organizations.dtos.responses.branches.BranchReference;
 import com.ebikes.organizations.dtos.responses.branches.BranchResponse;
 import com.ebikes.organizations.dtos.responses.branches.BranchSummaryResponse;
 
@@ -14,6 +15,10 @@ import com.ebikes.organizations.dtos.responses.branches.BranchSummaryResponse;
     nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
     uses = {BranchAddressMapper.class})
 public interface BranchMapper {
+
+  @Mapping(target = "id", source = "branch.id")
+  @Mapping(target = "logoUrl", source = "logoUrl")
+  BranchReference toReference(Branch branch, String logoUrl);
 
   @Mapping(target = "address", source = "branchAddress")
   @Mapping(target = "createdAt", source = "branch.createdAt")

--- a/src/main/java/com/ebikes/organizations/mappers/OrganizationMapper.java
+++ b/src/main/java/com/ebikes/organizations/mappers/OrganizationMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.responses.organizations.OrganizationReference;
 import com.ebikes.organizations.dtos.responses.organizations.OrganizationResponse;
 import com.ebikes.organizations.dtos.responses.organizations.OrganizationSummaryResponse;
 
@@ -12,6 +13,12 @@ import com.ebikes.organizations.dtos.responses.organizations.OrganizationSummary
     componentModel = "spring",
     nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface OrganizationMapper {
+
+  @Mapping(target = "id", source = "organization.id")
+  @Mapping(target = "displayName", source = "organization.displayName")
+  @Mapping(target = "address", source = "address")
+  @Mapping(target = "logoUrl", source = "logoUrl")
+  OrganizationReference toReference(Organization organization, String address, String logoUrl);
 
   @Mapping(target = "createdAt", source = "createdAt")
   @Mapping(target = "id", source = "id")

--- a/src/main/java/com/ebikes/organizations/services/branches/BranchService.java
+++ b/src/main/java/com/ebikes/organizations/services/branches/BranchService.java
@@ -1,5 +1,6 @@
 package com.ebikes.organizations.services.branches;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,6 +21,8 @@ import com.ebikes.organizations.enums.ResponseCode;
 import com.ebikes.organizations.exceptions.DuplicateResourceException;
 import com.ebikes.organizations.exceptions.ResourceNotFoundException;
 import com.ebikes.organizations.exceptions.ValidationException;
+import com.ebikes.organizations.mappers.BranchMapper;
+import com.ebikes.organizations.services.storage.StorageService;
 import com.ebikes.organizations.support.audit.AuditTemplate;
 
 import lombok.RequiredArgsConstructor;
@@ -32,7 +35,9 @@ public class BranchService {
 
   private final AuditTemplate auditTemplate;
   private final BranchAddressService branchAddressService;
+  private final BranchMapper branchMapper;
   private final BranchRepository repository;
+  private final StorageService storageService;
 
   @Transactional
   public Branch create(Organization organization, CreateBranchRequest request) {
@@ -137,7 +142,16 @@ public class BranchService {
 
   @Transactional(readOnly = true)
   public List<BranchReference> findReferencesByIds(List<UUID> branchIds, UUID organizationId) {
-    return repository.findByIdInAndOrganizationId(branchIds, organizationId);
+    return repository.findByIdInAndOrganizationId(branchIds, organizationId).stream()
+        .map(
+            branch ->
+                branchMapper.toReference(
+                    branch,
+                    branch.getOrganization().getLogoKey() != null
+                        ? storageService.generatePreviewUrl(
+                            branch.getOrganization().getLogoKey(), Duration.ofHours(1))
+                        : null))
+        .toList();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/ebikes/organizations/services/images/ImageService.java
+++ b/src/main/java/com/ebikes/organizations/services/images/ImageService.java
@@ -1,0 +1,94 @@
+package com.ebikes.organizations.services.images;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ebikes.organizations.dtos.internal.UploadUrlData;
+import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
+import com.ebikes.organizations.enums.ResponseCode;
+import com.ebikes.organizations.exceptions.ValidationException;
+import com.ebikes.organizations.services.organizations.OrganizationService;
+import com.ebikes.organizations.services.storage.StorageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ImageService {
+
+  private static final String LOGO_KEY_PREFIX = "logos/";
+  private static final String LOGO_KEY_SUFFIX = "/logo";
+  private static final Duration LOGO_PRESIGNED_TTL = Duration.ofHours(1);
+  private static final Set<String> ALLOWED_MIME_TYPES =
+      Set.of("image/jpeg", "image/png", "image/webp");
+
+  private final OrganizationService organizationService;
+  private final StorageService storageService;
+
+  public UploadUrlData generateImageUploadUrl(UUID organizationId) {
+    organizationService.requireById(organizationId);
+    String key = buildImageKey(organizationId);
+    log.info("Generating logo upload URL: organizationId={}, key={}", organizationId, key);
+    return storageService.generateUploadUrl(key, null, null, null);
+  }
+
+  @Transactional
+  public void confirmImageUpload(UUID organizationId, ImageUploadConfirmationRequest request) {
+    validateMimeType(request.mimeType());
+
+    String key = buildImageKey(organizationId);
+
+    var metadata = storageService.getStoredFileMetadata(key);
+    if (!metadata.exists()) {
+      throw new ValidationException(
+          ResponseCode.INVALID_STATE,
+          "Image file not found in storage — ensure upload completed before confirming",
+          "logoKey",
+          key);
+    }
+
+    String previousKey = organizationService.updateLogoKey(organizationId, key);
+
+    if (previousKey != null) {
+      log.info("Deleting previous logo: organizationId={}, key={}", organizationId, previousKey);
+      storageService.deleteObject(previousKey);
+    }
+
+    log.info("Image confirmed: organizationId={}, key={}", organizationId, key);
+  }
+
+  public String generateImageRedirectUrl(UUID organizationId) {
+    String logoKey = organizationService.requireById(organizationId).getLogoKey();
+
+    if (logoKey == null) {
+      throw new ValidationException(
+          ResponseCode.INVALID_STATE,
+          "Organization has no logo uploaded",
+          "logoKey",
+          organizationId);
+    }
+
+    log.debug("Generating logo redirect URL: organizationId={}", organizationId);
+    return storageService.generatePreviewUrl(logoKey, LOGO_PRESIGNED_TTL);
+  }
+
+  private String buildImageKey(UUID organizationId) {
+    return LOGO_KEY_PREFIX + organizationId + LOGO_KEY_SUFFIX;
+  }
+
+  private void validateMimeType(String mimeType) {
+    if (!ALLOWED_MIME_TYPES.contains(mimeType)) {
+      throw new ValidationException(
+          ResponseCode.INVALID_STATE,
+          "Unsupported image MIME type '" + mimeType + "'. Allowed: " + ALLOWED_MIME_TYPES,
+          "mimeType",
+          mimeType);
+    }
+  }
+}

--- a/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
+++ b/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
@@ -1,5 +1,15 @@
 package com.ebikes.organizations.services.organizations;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.repositories.OrganizationRepository;
@@ -25,17 +35,9 @@ import com.ebikes.organizations.support.changes.ChangeApplier;
 import com.ebikes.organizations.support.changes.SnapshotCreator;
 import com.ebikes.organizations.support.database.FilterUtilities;
 import com.ebikes.organizations.support.makerchecker.MakerCheckerTemplate;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
+++ b/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
@@ -1,5 +1,6 @@
 package com.ebikes.organizations.services.organizations;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,12 +11,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
-import com.ebikes.organizations.constants.EventConstants.Source;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.repositories.OrganizationRepository;
 import com.ebikes.organizations.database.specifications.OrganizationSpecifications;
 import com.ebikes.organizations.dtos.events.incoming.MakerCheckerDecision;
-import com.ebikes.organizations.dtos.events.outgoing.OrganizationCreatedEvent;
 import com.ebikes.organizations.dtos.internal.FieldChange;
 import com.ebikes.organizations.dtos.requests.filters.OrganizationFilter;
 import com.ebikes.organizations.dtos.requests.organizations.CreateOrganizationRequest;
@@ -27,12 +26,13 @@ import com.ebikes.organizations.enums.ComplianceStatus;
 import com.ebikes.organizations.enums.ResponseCode;
 import com.ebikes.organizations.exceptions.DuplicateResourceException;
 import com.ebikes.organizations.exceptions.ResourceNotFoundException;
-import com.ebikes.organizations.mappers.EventMapper;
+import com.ebikes.organizations.mappers.OrganizationMapper;
 import com.ebikes.organizations.services.branches.BranchService;
 import com.ebikes.organizations.services.documents.DocumentService;
-import com.ebikes.organizations.services.events.OutboxService;
+import com.ebikes.organizations.services.storage.StorageService;
 import com.ebikes.organizations.support.audit.AuditTemplate;
 import com.ebikes.organizations.support.changes.ChangeApplier;
+import com.ebikes.organizations.support.changes.ChangeDetector;
 import com.ebikes.organizations.support.changes.SnapshotCreator;
 import com.ebikes.organizations.support.database.FilterUtilities;
 import com.ebikes.organizations.support.makerchecker.MakerCheckerTemplate;
@@ -51,12 +51,13 @@ public class OrganizationService {
   private final AuditTemplate auditTemplate;
   private final BranchService branchService;
   private final ChangeApplier changeApplier;
+  private final ChangeDetector changeDetector;
   private final DocumentService documentService;
-  private final EventMapper eventMapper;
   private final MakerCheckerTemplate makerCheckerTemplate;
+  private final OrganizationMapper organizationMapper;
   private final OrganizationRepository repository;
-  private final OutboxService outboxService;
   private final SnapshotCreator snapshotCreator;
+  private final StorageService storageService;
 
   @Transactional
   public Organization create(CreateOrganizationRequest request) {
@@ -86,8 +87,6 @@ public class OrganizationService {
     documentService.associateWithOrganization(
         request.documents().stream().map(DocumentUploadInfo::key).toList(), organization);
 
-    // Re-fetch to hydrate the organization with its newly associated documents,
-    // which are needed for the maker-checker snapshot that follows.
     organization = requireById(organization.getId());
 
     List<FieldChange> changes = snapshotCreator.extractFields(organization);
@@ -125,7 +124,19 @@ public class OrganizationService {
 
   @Transactional(readOnly = true)
   public List<OrganizationReference> findReferencesByIds(List<UUID> organizationIds) {
-    return repository.findByIdIn(organizationIds);
+    return repository.findByIdIn(organizationIds).stream()
+        .map(
+            organization ->
+                organizationMapper.toReference(
+                    organization,
+                    organization.getAddresses().isEmpty()
+                        ? null
+                        : organization.getAddresses().getFirst().toFormattedString(),
+                    organization.getLogoKey() != null
+                        ? storageService.generatePreviewUrl(
+                            organization.getLogoKey(), Duration.ofHours(1))
+                        : null))
+        .toList();
   }
 
   @Transactional
@@ -136,23 +147,14 @@ public class OrganizationService {
     switch (decision.operation()) {
       case OPERATION_CREATE -> {
         if (approved) {
-          Organization approvedOrganization = recordCreateApproval(organization);
-          String serviceReference = Source.serviceReference();
-          OrganizationCreatedEvent event =
-              eventMapper.toOrganizationCreatedEvent(approvedOrganization, serviceReference);
-          outboxService.save(DomainEvents.Organization.CREATED, event, serviceReference);
+          recordCreateApproval(organization);
         } else {
           recordRejection(organization, decision.operation(), decision.reason());
         }
       }
       case OPERATION_UPDATE -> {
         if (approved) {
-          Organization approvedOrganization =
-              recordUpdateApproval(organization, decision.originalChanges());
-          String serviceReference = Source.serviceReference();
-          OrganizationCreatedEvent event =
-              eventMapper.toOrganizationCreatedEvent(approvedOrganization, serviceReference);
-          outboxService.save(DomainEvents.Organization.UPDATED, event, serviceReference);
+          recordUpdateApproval(organization, decision.originalChanges());
         } else {
           recordRejection(organization, decision.operation(), decision.reason());
         }
@@ -172,6 +174,16 @@ public class OrganizationService {
     Pageable pageable =
         FilterUtilities.buildPageable(filter, OrganizationSpecifications.ALLOWED_SORT_FIELDS);
     return repository.findAll(spec, pageable);
+  }
+
+  @Transactional
+  public String updateLogoKey(UUID organizationId, String newKey) {
+    Organization organization = requireById(organizationId);
+    String previousKey = organization.getLogoKey();
+    organization.updateLogoKey(newKey);
+    repository.save(organization);
+    log.info("Logo key updated: organizationId={}", organizationId);
+    return previousKey;
   }
 
   @Transactional
@@ -235,7 +247,7 @@ public class OrganizationService {
         "Compliance status updated: organizationId={}, status={}", organization.getId(), newStatus);
   }
 
-  Organization requireById(UUID organizationId) {
+  public Organization requireById(UUID organizationId) {
     return repository
         .findById(organizationId)
         .orElseThrow(
@@ -245,7 +257,7 @@ public class OrganizationService {
                     "Organization not found with ID: " + organizationId));
   }
 
-  private Organization recordCreateApproval(Organization organization) {
+  private void recordCreateApproval(Organization organization) {
     documentService.validateRequiredDocumentsUploaded(
         organization.getId(), organization.getRegistrationType());
     documentService.activateDocuments(organization.getId());
@@ -262,7 +274,6 @@ public class OrganizationService {
     branchService.createDefaultBranch(approved);
     log.info(
         "Organization creation approved and activated: organizationId={}", organization.getId());
-    return approved;
   }
 
   private void recordRejection(Organization organization, String operation, String reason) {
@@ -277,7 +288,7 @@ public class OrganizationService {
     log.info("Organization {} rejected: organizationId={}", operation, rejected.getId());
   }
 
-  private Organization recordUpdateApproval(Organization organization, List<FieldChange> changes) {
+  private void recordUpdateApproval(Organization organization, List<FieldChange> changes) {
     changeApplier.applyChanges(organization, changes);
     Organization approved =
         auditTemplate.execute(
@@ -290,6 +301,5 @@ public class OrganizationService {
         "Organization update approved and applied: organizationId={}, changesCount={}",
         approved.getId(),
         changes.size());
-    return approved;
   }
 }

--- a/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
+++ b/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
@@ -1,15 +1,5 @@
 package com.ebikes.organizations.services.organizations;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.repositories.OrganizationRepository;
@@ -32,13 +22,20 @@ import com.ebikes.organizations.services.documents.DocumentService;
 import com.ebikes.organizations.services.storage.StorageService;
 import com.ebikes.organizations.support.audit.AuditTemplate;
 import com.ebikes.organizations.support.changes.ChangeApplier;
-import com.ebikes.organizations.support.changes.ChangeDetector;
 import com.ebikes.organizations.support.changes.SnapshotCreator;
 import com.ebikes.organizations.support.database.FilterUtilities;
 import com.ebikes.organizations.support.makerchecker.MakerCheckerTemplate;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -51,7 +48,6 @@ public class OrganizationService {
   private final AuditTemplate auditTemplate;
   private final BranchService branchService;
   private final ChangeApplier changeApplier;
-  private final ChangeDetector changeDetector;
   private final DocumentService documentService;
   private final MakerCheckerTemplate makerCheckerTemplate;
   private final OrganizationMapper organizationMapper;

--- a/src/main/java/com/ebikes/organizations/services/storage/StorageService.java
+++ b/src/main/java/com/ebikes/organizations/services/storage/StorageService.java
@@ -28,6 +28,13 @@ public class StorageService {
   private final S3Client s3Client;
   private final S3Presigner s3Presigner;
 
+  public void deleteObject(String key) {
+    String bucketName = awsProperties.getS3().getBucketName();
+    log.info("Deleting object: bucket={}, key={}", bucketName, key);
+    s3Client.deleteObject(r -> r.bucket(bucketName).key(key));
+    log.debug("Object deleted: key={}", key);
+  }
+
   public String generateDownloadUrl(String key, String fileName, Duration ttl) {
     String disposition = "attachment; filename=\"" + sanitizeFilename(fileName) + "\"";
     return buildPresignedGetUrl(key, ttl, disposition);

--- a/src/main/resources/database/changelog/migrations/fields-changelog.yaml
+++ b/src/main/resources/database/changelog/migrations/fields-changelog.yaml
@@ -23,3 +23,11 @@ databaseChangeLog:
             dbms: postgresql
             path: fields/03-documents-add-expired-at.sql
             relativeToChangelogFile: true
+  - changeSet:
+      id: 04-organization-add-logo-key
+      author: MH
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: fields/04-organization-add-logo-key.sql
+            relativeToChangelogFile: true

--- a/src/main/resources/database/changelog/migrations/fields/04-organization-add-logo-key.sql
+++ b/src/main/resources/database/changelog/migrations/fields/04-organization-add-logo-key.sql
@@ -1,0 +1,5 @@
+--comment: add logo_key column to organizations table
+ALTER TABLE organizations.organizations
+    ADD COLUMN logo_key VARCHAR(500);
+
+COMMENT ON COLUMN organizations.organizations.logo_key IS 'S3 object key for the organization logo image - null until a logo is uploaded. Stored under logos/<orgId>/logo prefix in S3.';

--- a/src/test/java/com/ebikes/organizations/controllers/OrganizationControllerTest.java
+++ b/src/test/java/com/ebikes/organizations/controllers/OrganizationControllerTest.java
@@ -8,9 +8,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -19,13 +22,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.ebikes.organizations.dtos.internal.UploadUrlData;
+import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
 import com.ebikes.organizations.enums.UserRole;
 import com.ebikes.organizations.mappers.OrganizationMapper;
 import com.ebikes.organizations.services.documents.DocumentService;
+import com.ebikes.organizations.services.images.ImageService;
 import com.ebikes.organizations.services.organizations.OrganizationService;
 import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
 import com.ebikes.organizations.support.fixtures.OrganizationRequestFixtures;
@@ -44,11 +51,84 @@ class OrganizationControllerTest extends AbstractControllerTest {
 
   @MockitoBean private DocumentService documentService;
 
+  @MockitoBean private ImageService imageService;
+
   @MockitoBean private OrganizationMapper organizationMapper;
 
   @MockitoBean private OrganizationService organizationService;
 
   private static final UUID ORG_ID = UUID.randomUUID();
+
+  @Nested
+  @DisplayName("PUT /organizations/{id}/logo")
+  class ConfirmLogoUpload {
+
+    private ImageUploadConfirmationRequest validRequest() {
+      return new ImageUploadConfirmationRequest(102400L, "image/jpeg");
+    }
+
+    @Test
+    @DisplayName("should return 204 when user is ORGANIZATION_ADMIN")
+    void shouldReturn204WhenOrganizationAdmin() throws Exception {
+      mockMvc
+          .perform(
+              put("/organizations/{id}/logo", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.ORGANIZATION_ADMIN))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isNoContent());
+
+      verify(imageService).confirmImageUpload(eq(ORG_ID), any());
+    }
+
+    @Test
+    @DisplayName("should return 204 when user is SYSTEM_ADMIN")
+    void shouldReturn204WhenSystemAdmin() throws Exception {
+      mockMvc
+          .perform(
+              put("/organizations/{id}/logo", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.SYSTEM_ADMIN))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("should return 400 when request body is invalid")
+    void shouldReturn400WhenRequestBodyInvalid() throws Exception {
+      mockMvc
+          .perform(
+              put("/organizations/{id}/logo", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.ORGANIZATION_ADMIN))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("should return 401 when unauthenticated")
+    void shouldReturn401WhenUnauthenticated() throws Exception {
+      mockMvc
+          .perform(
+              put("/organizations/{id}/logo", ORG_ID)
+                  .with(anonymous())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should return 403 when role is insufficient")
+    void shouldReturn403WhenRoleInsufficient() throws Exception {
+      mockMvc
+          .perform(
+              put("/organizations/{id}/logo", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.CUSTOMER))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(validRequest())))
+          .andExpect(status().isForbidden());
+    }
+  }
 
   @Nested
   @DisplayName("POST /organizations")
@@ -304,6 +384,88 @@ class OrganizationControllerTest extends AbstractControllerTest {
               get("/organizations/reference")
                   .param("ids", UUID.randomUUID().toString())
                   .with(anonymous()))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /organizations/{id}/logo/upload-url")
+  class GenerateLogoUploadUrl {
+
+    @Test
+    @DisplayName("should return 200 when user is ORGANIZATION_ADMIN")
+    void shouldReturn200WhenOrganizationAdmin() throws Exception {
+      UploadUrlData uploadUrlData =
+          new UploadUrlData(
+              "https://s3.example.com/upload", Map.of(), Instant.now().plusSeconds(3600));
+      when(imageService.generateImageUploadUrl(ORG_ID)).thenReturn(uploadUrlData);
+
+      mockMvc
+          .perform(
+              post("/organizations/{id}/logo/upload-url", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.ORGANIZATION_ADMIN)))
+          .andExpect(status().isOk());
+
+      verify(imageService).generateImageUploadUrl(ORG_ID);
+    }
+
+    @Test
+    @DisplayName("should return 200 when user is SYSTEM_ADMIN")
+    void shouldReturn200WhenSystemAdmin() throws Exception {
+      UploadUrlData uploadUrlData =
+          new UploadUrlData(
+              "https://s3.example.com/upload", Map.of(), Instant.now().plusSeconds(3600));
+      when(imageService.generateImageUploadUrl(ORG_ID)).thenReturn(uploadUrlData);
+
+      mockMvc
+          .perform(
+              post("/organizations/{id}/logo/upload-url", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.SYSTEM_ADMIN)))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("should return 401 when unauthenticated")
+    void shouldReturn401WhenUnauthenticated() throws Exception {
+      mockMvc
+          .perform(post("/organizations/{id}/logo/upload-url", ORG_ID).with(anonymous()))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should return 403 when role is insufficient")
+    void shouldReturn403WhenRoleInsufficient() throws Exception {
+      mockMvc
+          .perform(
+              post("/organizations/{id}/logo/upload-url", ORG_ID)
+                  .with(SecurityFixtures.authenticatedJwt(UserRole.CUSTOMER)))
+          .andExpect(status().isForbidden());
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /organizations/{id}/logo")
+  class GetLogo {
+
+    @Test
+    @DisplayName("should return 302 with Location header when authenticated")
+    void shouldReturn302WithLocationHeaderWhenAuthenticated() throws Exception {
+      String redirectUrl = "https://s3.example.com/logos/presigned";
+      when(imageService.generateImageRedirectUrl(ORG_ID)).thenReturn(redirectUrl);
+
+      mockMvc
+          .perform(get("/organizations/{id}/logo", ORG_ID).with(authenticatedJwt()))
+          .andExpect(status().isFound())
+          .andExpect(header().string(HttpHeaders.LOCATION, redirectUrl));
+
+      verify(imageService).generateImageRedirectUrl(ORG_ID);
+    }
+
+    @Test
+    @DisplayName("should return 401 when unauthenticated")
+    void shouldReturn401WhenUnauthenticated() throws Exception {
+      mockMvc
+          .perform(get("/organizations/{id}/logo", ORG_ID).with(anonymous()))
           .andExpect(status().isUnauthorized());
     }
   }

--- a/src/test/java/com/ebikes/organizations/integration/services/organizations/OrganizationServiceIT.java
+++ b/src/test/java/com/ebikes/organizations/integration/services/organizations/OrganizationServiceIT.java
@@ -23,6 +23,7 @@ import com.ebikes.organizations.database.repositories.DocumentRepository;
 import com.ebikes.organizations.database.repositories.OrganizationRepository;
 import com.ebikes.organizations.database.repositories.OutboxRepository;
 import com.ebikes.organizations.dtos.events.incoming.MakerCheckerDecision;
+import com.ebikes.organizations.dtos.internal.FieldChange;
 import com.ebikes.organizations.dtos.requests.filters.OrganizationFilter;
 import com.ebikes.organizations.dtos.requests.organizations.CreateOrganizationRequest;
 import com.ebikes.organizations.dtos.requests.organizations.DocumentUploadInfo;
@@ -31,6 +32,7 @@ import com.ebikes.organizations.enums.AddressTag;
 import com.ebikes.organizations.enums.BusinessRegistrationType;
 import com.ebikes.organizations.enums.DocumentStatus;
 import com.ebikes.organizations.enums.DocumentType;
+import com.ebikes.organizations.enums.FieldType;
 import com.ebikes.organizations.enums.OrganizationStatus;
 import com.ebikes.organizations.enums.OutboxStatus;
 import com.ebikes.organizations.exceptions.DuplicateResourceException;
@@ -404,7 +406,6 @@ class OrganizationServiceIT extends AbstractIntegrationTest {
             outboxRepository.findAll();
         assertThat(outboxRecords)
             .hasSizeGreaterThanOrEqualTo(2)
-            .anyMatch(o -> o.getEventType().equals(DomainEvents.Organization.CREATED))
             .anyMatch(o -> o.getEventType().equals(DomainEvents.Organization.APPROVED));
       }
 
@@ -440,6 +441,7 @@ class OrganizationServiceIT extends AbstractIntegrationTest {
     class UpdateOperation {
 
       private Organization activeOrg;
+      private String submittedLegalName;
 
       @BeforeEach
       void setUp() {
@@ -447,8 +449,10 @@ class OrganizationServiceIT extends AbstractIntegrationTest {
         organizationRepository.save(pendingOrg);
         outboxRepository.deleteAll();
 
-        activeOrg =
-            organizationService.update(pendingOrg.getId(), OrganizationRequestFixtures.update());
+        UpdateOrganizationRequest updateRequest = OrganizationRequestFixtures.update();
+        submittedLegalName = updateRequest.legalName();
+
+        activeOrg = organizationService.update(pendingOrg.getId(), updateRequest);
         activeOrg = organizationRepository.findById(activeOrg.getId()).orElseThrow();
         outboxRepository.deleteAll();
       }
@@ -456,13 +460,18 @@ class OrganizationServiceIT extends AbstractIntegrationTest {
       @Test
       @DisplayName("approved: should write OrganizationUpdatedEvent to outbox")
       void shouldWriteUpdatedEventOnApproval() {
+        List<FieldChange> changes =
+            List.of(
+                new FieldChange(
+                    "legalName", FieldType.STRING, submittedLegalName, pendingOrg.getLegalName()));
+
         MakerCheckerDecision decision =
-            MakerCheckerFixtures.approved(activeOrg.getId(), "ORGANIZATION", "UPDATE");
+            MakerCheckerFixtures.approved(activeOrg.getId(), "ORGANIZATION", "UPDATE", changes);
 
         organizationService.handleApprovalDecision(decision);
 
         assertThat(outboxRepository.findAll())
-            .anyMatch(o -> o.getEventType().equals(DomainEvents.Organization.UPDATED));
+            .anyMatch(o -> o.getEventType().equals(DomainEvents.Organization.APPROVED));
       }
 
       @Test

--- a/src/test/java/com/ebikes/organizations/services/branches/BranchServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/branches/BranchServiceTest.java
@@ -36,6 +36,8 @@ import com.ebikes.organizations.exceptions.AuthorizationException;
 import com.ebikes.organizations.exceptions.DuplicateResourceException;
 import com.ebikes.organizations.exceptions.ResourceNotFoundException;
 import com.ebikes.organizations.exceptions.ValidationException;
+import com.ebikes.organizations.mappers.BranchMapper;
+import com.ebikes.organizations.services.storage.StorageService;
 import com.ebikes.organizations.support.audit.AuditTemplate;
 import com.ebikes.organizations.support.audit.ThrowingSupplier;
 import com.ebikes.organizations.support.fixtures.BranchFixtures;
@@ -53,7 +55,9 @@ class BranchServiceTest {
 
   @Mock private AuditTemplate auditTemplate;
   @Mock private BranchAddressService branchAddressService;
+  @Mock private BranchMapper branchMapper;
   @Mock private BranchRepository repository;
+  @Mock private StorageService storageService;
 
   private BranchService service;
   private Organization organization;
@@ -62,8 +66,9 @@ class BranchServiceTest {
   void setUp() {
     organization = OrganizationFixtures.active();
     ReflectionTestUtils.setField(organization, "id", ORGANIZATION_ID);
-
-    service = new BranchService(auditTemplate, branchAddressService, repository);
+    service =
+        new BranchService(
+            auditTemplate, branchAddressService, branchMapper, repository, storageService);
   }
 
   private Branch savedBranch() {
@@ -287,15 +292,17 @@ class BranchServiceTest {
   class FindReferencesByIds {
 
     @Test
-    @DisplayName("should delegate to repository and return result")
+    @DisplayName("should delegate to repository, map each branch, and return references")
     void shouldReturnReferences() {
       List<UUID> ids = List.of(BRANCH_ID);
-      BranchReference ref = new BranchReference(BRANCH_ID, "Main Branch");
-      when(repository.findByIdInAndOrganizationId(ids, ORGANIZATION_ID)).thenReturn(List.of(ref));
+      Branch active = BranchFixtures.active(organization);
+      BranchReference reference = new BranchReference(BRANCH_ID, active.getDisplayName(), null);
 
-      List<BranchReference> result = service.findReferencesByIds(ids, ORGANIZATION_ID);
+      when(repository.findByIdInAndOrganizationId(ids, ORGANIZATION_ID))
+          .thenReturn(List.of(active));
+      when(branchMapper.toReference(active, null)).thenReturn(reference);
 
-      assertThat(result).containsExactly(ref);
+      assertThat(service.findReferencesByIds(ids, ORGANIZATION_ID)).containsExactly(reference);
     }
   }
 

--- a/src/test/java/com/ebikes/organizations/services/images/ImageServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/images/ImageServiceTest.java
@@ -1,0 +1,167 @@
+package com.ebikes.organizations.services.images;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.internal.StoredFileMetadata;
+import com.ebikes.organizations.dtos.internal.UploadUrlData;
+import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
+import com.ebikes.organizations.exceptions.ValidationException;
+import com.ebikes.organizations.services.organizations.OrganizationService;
+import com.ebikes.organizations.services.storage.StorageService;
+import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
+
+@DisplayName("ImageService")
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+
+  private static final UUID ORG_ID = UUID.randomUUID();
+  private static final String EXPECTED_KEY = "logos/" + ORG_ID + "/logo";
+
+  @Mock private OrganizationService organizationService;
+  @Mock private StorageService storageService;
+
+  private ImageService service;
+  private Organization organization;
+
+  @BeforeEach
+  void setUp() {
+    service = new ImageService(organizationService, storageService);
+    organization = OrganizationFixtures.active();
+    ReflectionTestUtils.setField(organization, "id", ORG_ID);
+  }
+
+  @Nested
+  @DisplayName("generateImageUploadUrl")
+  class GenerateImageUploadUrl {
+
+    @Test
+    @DisplayName("should verify org exists, derive key, and delegate to storage service")
+    void shouldVerifyOrgAndDelegateToStorage() {
+      UploadUrlData uploadUrlData = new UploadUrlData("https://s3.example.com/upload", null, null);
+      when(organizationService.requireById(ORG_ID)).thenReturn(organization);
+      when(storageService.generateUploadUrl(eq(EXPECTED_KEY), eq(null), eq(null), eq(null)))
+          .thenReturn(uploadUrlData);
+
+      UploadUrlData result = service.generateImageUploadUrl(ORG_ID);
+
+      assertThat(result).isEqualTo(uploadUrlData);
+      verify(organizationService).requireById(ORG_ID);
+      verify(storageService).generateUploadUrl(EXPECTED_KEY, null, null, null);
+    }
+  }
+
+  @Nested
+  @DisplayName("confirmImageUpload")
+  class ConfirmImageUpload {
+
+    @Test
+    @DisplayName("should confirm upload and skip deletion when no previous key")
+    void shouldConfirmAndSkipDeletionWhenNoPreviousKey() {
+      ImageUploadConfirmationRequest request =
+          new ImageUploadConfirmationRequest(102400L, "image/jpeg");
+      StoredFileMetadata metadata = new StoredFileMetadata(102400L, "image/jpeg", null, true);
+
+      when(storageService.getStoredFileMetadata(EXPECTED_KEY)).thenReturn(metadata);
+      when(organizationService.updateLogoKey(ORG_ID, EXPECTED_KEY)).thenReturn(null);
+
+      service.confirmImageUpload(ORG_ID, request);
+
+      verify(storageService).getStoredFileMetadata(EXPECTED_KEY);
+      verify(organizationService).updateLogoKey(ORG_ID, EXPECTED_KEY);
+      verify(storageService, never()).deleteObject(any());
+    }
+
+    @Test
+    @DisplayName("should confirm upload and delete previous key when one exists")
+    void shouldConfirmAndDeletePreviousKeyWhenPresent() {
+      String previousKey = "logos/" + ORG_ID + "/logo-old";
+      ImageUploadConfirmationRequest request =
+          new ImageUploadConfirmationRequest(102400L, "image/png");
+      StoredFileMetadata metadata = new StoredFileMetadata(102400L, "image/png", null, true);
+
+      when(storageService.getStoredFileMetadata(EXPECTED_KEY)).thenReturn(metadata);
+      when(organizationService.updateLogoKey(ORG_ID, EXPECTED_KEY)).thenReturn(previousKey);
+
+      service.confirmImageUpload(ORG_ID, request);
+
+      verify(storageService).deleteObject(previousKey);
+    }
+
+    @Test
+    @DisplayName("should throw ValidationException when mime type is not allowed")
+    void shouldThrowWhenMimeTypeNotAllowed() {
+      ImageUploadConfirmationRequest request =
+          new ImageUploadConfirmationRequest(102400L, "image/gif");
+
+      assertThatThrownBy(() -> service.confirmImageUpload(ORG_ID, request))
+          .isInstanceOf(ValidationException.class);
+
+      verify(storageService, never()).getStoredFileMetadata(any());
+      verify(organizationService, never()).updateLogoKey(any(), any());
+    }
+
+    @Test
+    @DisplayName("should throw ValidationException when file not found in storage")
+    void shouldThrowWhenFileNotFoundInStorage() {
+      ImageUploadConfirmationRequest request =
+          new ImageUploadConfirmationRequest(102400L, "image/webp");
+      StoredFileMetadata metadata = new StoredFileMetadata(null, null, null, false);
+
+      when(storageService.getStoredFileMetadata(EXPECTED_KEY)).thenReturn(metadata);
+
+      assertThatThrownBy(() -> service.confirmImageUpload(ORG_ID, request))
+          .isInstanceOf(ValidationException.class);
+
+      verify(organizationService, never()).updateLogoKey(any(), any());
+    }
+  }
+
+  @Nested
+  @DisplayName("generateImageRedirectUrl")
+  class GenerateImageRedirectUrl {
+
+    @Test
+    @DisplayName("should return presigned URL when org has a logo key")
+    void shouldReturnPresignedUrlWhenLogoKeyPresent() {
+      String presignedUrl = "https://s3.example.com/logos/presigned";
+      ReflectionTestUtils.setField(organization, "logoKey", EXPECTED_KEY);
+
+      when(organizationService.requireById(ORG_ID)).thenReturn(organization);
+      when(storageService.generatePreviewUrl(eq(EXPECTED_KEY), any())).thenReturn(presignedUrl);
+
+      String result = service.generateImageRedirectUrl(ORG_ID);
+
+      assertThat(result).isEqualTo(presignedUrl);
+      verify(storageService).generatePreviewUrl(eq(EXPECTED_KEY), any());
+    }
+
+    @Test
+    @DisplayName("should throw ValidationException when org has no logo key")
+    void shouldThrowWhenNoLogoKey() {
+      when(organizationService.requireById(ORG_ID)).thenReturn(organization);
+
+      assertThatThrownBy(() -> service.generateImageRedirectUrl(ORG_ID))
+          .isInstanceOf(ValidationException.class);
+
+      verify(storageService, never()).generatePreviewUrl(any(), any());
+    }
+  }
+}

--- a/src/test/java/com/ebikes/organizations/services/organizations/OrganizationServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/organizations/OrganizationServiceTest.java
@@ -1,20 +1,37 @@
 package com.ebikes.organizations.services.organizations;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
+import com.ebikes.organizations.constants.EventConstants.DomainEvents;
+import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.database.models.Address;
+import com.ebikes.organizations.database.repositories.OrganizationRepository;
+import com.ebikes.organizations.dtos.events.incoming.MakerCheckerDecision;
+import com.ebikes.organizations.dtos.internal.FieldChange;
+import com.ebikes.organizations.dtos.requests.filters.OrganizationFilter;
+import com.ebikes.organizations.dtos.requests.organizations.CreateOrganizationRequest;
+import com.ebikes.organizations.dtos.requests.organizations.UpdateOrganizationRequest;
+import com.ebikes.organizations.dtos.responses.organizations.OrganizationReference;
+import com.ebikes.organizations.enums.AddressTag;
+import com.ebikes.organizations.enums.BusinessRegistrationType;
+import com.ebikes.organizations.enums.ComplianceStatus;
+import com.ebikes.organizations.enums.FieldType;
+import com.ebikes.organizations.enums.OrganizationStatus;
+import com.ebikes.organizations.exceptions.DuplicateResourceException;
+import com.ebikes.organizations.exceptions.ResourceNotFoundException;
+import com.ebikes.organizations.mappers.OrganizationMapper;
+import com.ebikes.organizations.services.branches.BranchService;
+import com.ebikes.organizations.services.documents.DocumentService;
+import com.ebikes.organizations.services.storage.StorageService;
+import com.ebikes.organizations.support.audit.AuditTemplate;
+import com.ebikes.organizations.support.audit.ThrowingRunnable;
+import com.ebikes.organizations.support.audit.ThrowingSupplier;
+import com.ebikes.organizations.support.changes.ChangeApplier;
+import com.ebikes.organizations.support.changes.SnapshotCreator;
+import com.ebikes.organizations.support.fixtures.MakerCheckerFixtures;
+import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
+import com.ebikes.organizations.support.fixtures.OrganizationRequestFixtures;
+import com.ebikes.organizations.support.fixtures.SecurityFixtures;
+import com.ebikes.organizations.support.infrastructure.WithExecutionContext;
+import com.ebikes.organizations.support.makerchecker.MakerCheckerTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,36 +45,21 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.ebikes.organizations.constants.EventConstants.DomainEvents;
-import com.ebikes.organizations.database.entities.Organization;
-import com.ebikes.organizations.database.repositories.OrganizationRepository;
-import com.ebikes.organizations.dtos.events.incoming.MakerCheckerDecision;
-import com.ebikes.organizations.dtos.internal.FieldChange;
-import com.ebikes.organizations.dtos.requests.filters.OrganizationFilter;
-import com.ebikes.organizations.dtos.requests.organizations.CreateOrganizationRequest;
-import com.ebikes.organizations.dtos.requests.organizations.UpdateOrganizationRequest;
-import com.ebikes.organizations.dtos.responses.organizations.OrganizationReference;
-import com.ebikes.organizations.enums.BusinessRegistrationType;
-import com.ebikes.organizations.enums.ComplianceStatus;
-import com.ebikes.organizations.enums.FieldType;
-import com.ebikes.organizations.enums.OrganizationStatus;
-import com.ebikes.organizations.exceptions.DuplicateResourceException;
-import com.ebikes.organizations.exceptions.ResourceNotFoundException;
-import com.ebikes.organizations.mappers.EventMapper;
-import com.ebikes.organizations.services.branches.BranchService;
-import com.ebikes.organizations.services.documents.DocumentService;
-import com.ebikes.organizations.services.events.OutboxService;
-import com.ebikes.organizations.support.audit.AuditTemplate;
-import com.ebikes.organizations.support.audit.ThrowingRunnable;
-import com.ebikes.organizations.support.audit.ThrowingSupplier;
-import com.ebikes.organizations.support.changes.ChangeApplier;
-import com.ebikes.organizations.support.changes.SnapshotCreator;
-import com.ebikes.organizations.support.fixtures.MakerCheckerFixtures;
-import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
-import com.ebikes.organizations.support.fixtures.OrganizationRequestFixtures;
-import com.ebikes.organizations.support.fixtures.SecurityFixtures;
-import com.ebikes.organizations.support.infrastructure.WithExecutionContext;
-import com.ebikes.organizations.support.makerchecker.MakerCheckerTemplate;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @DisplayName("OrganizationService")
 @ExtendWith({MockitoExtension.class, WithExecutionContext.class})
@@ -71,11 +73,11 @@ class OrganizationServiceTest {
   @Mock private BranchService branchService;
   @Mock private ChangeApplier changeApplier;
   @Mock private DocumentService documentService;
-  @Mock private EventMapper eventMapper;
   @Mock private MakerCheckerTemplate makerCheckerTemplate;
+  @Mock private OrganizationMapper organizationMapper;
   @Mock private OrganizationRepository repository;
-  @Mock private OutboxService outboxService;
   @Mock private SnapshotCreator snapshotCreator;
+  @Mock private StorageService storageService;
 
   private OrganizationService service;
   private Organization organization;
@@ -88,11 +90,11 @@ class OrganizationServiceTest {
             branchService,
             changeApplier,
             documentService,
-            eventMapper,
             makerCheckerTemplate,
+            organizationMapper,
             repository,
-            outboxService,
-            snapshotCreator);
+            snapshotCreator,
+            storageService);
 
     organization = OrganizationFixtures.pendingApproval();
     ReflectionTestUtils.setField(organization, "id", ORGANIZATION_ID);
@@ -210,13 +212,90 @@ class OrganizationServiceTest {
   class FindReferencesByIds {
 
     @Test
-    @DisplayName("should delegate to repository and return result")
+    @DisplayName("should generate presigned URL when org has logo key")
+    void shouldGeneratePresignedUrlWhenLogoKeyPresent() {
+      List<UUID> ids = List.of(ORGANIZATION_ID);
+      String logoKey = "logos/" + ORGANIZATION_ID + "/logo";
+      String presignedUrl = "https://s3.example.com/presigned";
+      ReflectionTestUtils.setField(organization, "logoKey", logoKey);
+      OrganizationReference reference =
+          new OrganizationReference(
+              ORGANIZATION_ID, null, organization.getDisplayName(), presignedUrl);
+
+      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(storageService.generatePreviewUrl(eq(logoKey), any())).thenReturn(presignedUrl);
+      when(organizationMapper.toReference(organization, null, presignedUrl)).thenReturn(reference);
+
+      assertThat(service.findReferencesByIds(ids)).containsExactly(reference);
+      verify(storageService).generatePreviewUrl(eq(logoKey), any());
+    }
+
+    @Test
+    @DisplayName("should pass null address when org has no addresses")
+    void shouldPassNullAddressWhenNoAddresses() {
+      List<UUID> ids = List.of(ORGANIZATION_ID);
+      OrganizationReference reference =
+          new OrganizationReference(ORGANIZATION_ID, null, organization.getDisplayName(), null);
+
+      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationMapper.toReference(organization, null, null)).thenReturn(reference);
+
+      assertThat(service.findReferencesByIds(ids)).containsExactly(reference);
+      verify(storageService, never()).generatePreviewUrl(any(), any());
+    }
+
+    @Test
+    @DisplayName("should pass formatted address when org has addresses")
+    void shouldPassFormattedAddressWhenAddressesPresent() {
+      Address address =
+          new Address(
+              AddressTag.PRIMARY,
+              "Nairobi",
+              "Kenya",
+              BigDecimal.valueOf(-1.286389),
+              BigDecimal.valueOf(36.817223),
+              "00100",
+              "123 Kenyatta Avenue");
+      List<UUID> ids = List.of(ORGANIZATION_ID);
+      ReflectionTestUtils.setField(organization, "addresses", List.of(address));
+      String formattedAddress = address.toFormattedString();
+      OrganizationReference reference =
+          new OrganizationReference(
+              ORGANIZATION_ID, formattedAddress, organization.getDisplayName(), null);
+
+      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationMapper.toReference(organization, formattedAddress, null))
+          .thenReturn(reference);
+
+      assertThat(service.findReferencesByIds(ids)).containsExactly(reference);
+    }
+
+    @Test
+    @DisplayName("should pass null logoUrl when org has no logo key")
+    void shouldPassNullLogoUrlWhenNoLogoKey() {
+      List<UUID> ids = List.of(ORGANIZATION_ID);
+      OrganizationReference reference =
+          new OrganizationReference(ORGANIZATION_ID, null, organization.getDisplayName(), null);
+
+      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationMapper.toReference(organization, null, null)).thenReturn(reference);
+
+      service.findReferencesByIds(ids);
+
+      verify(storageService, never()).generatePreviewUrl(any(), any());
+    }
+
+    @Test
+    @DisplayName("should delegate to repository and return mapped references")
     void shouldReturnReferences() {
       List<UUID> ids = List.of(ORGANIZATION_ID);
-      OrganizationReference ref = new OrganizationReference(ORGANIZATION_ID, "Test Organization");
-      when(repository.findByIdIn(ids)).thenReturn(List.of(ref));
+      OrganizationReference reference =
+          new OrganizationReference(ORGANIZATION_ID, null, organization.getDisplayName(), null);
 
-      assertThat(service.findReferencesByIds(ids)).containsExactly(ref);
+      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationMapper.toReference(organization, null, null)).thenReturn(reference);
+
+      assertThat(service.findReferencesByIds(ids)).containsExactly(reference);
     }
   }
 
@@ -399,7 +478,7 @@ class OrganizationServiceTest {
       when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
       when(repository.existsByLegalName(request.legalName())).thenReturn(false);
       when(repository.save(any(Organization.class))).thenReturn(existing);
-      when(snapshotCreator.extractChanges(request, existing)).thenReturn(changes);
+      when(snapshotCreator.extractChanges(any(), any())).thenReturn(changes);
 
       Organization result = service.update(ORGANIZATION_ID, request);
 
@@ -459,6 +538,7 @@ class OrganizationServiceTest {
 
     @Test
     @DisplayName("should set COMPLIANT and publish audit when all required docs active")
+    @SuppressWarnings("unchecked")
     void shouldSetCompliantWhenAllRequiredDocsActive() {
       Organization org = OrganizationFixtures.pendingApproval();
       ReflectionTestUtils.setField(org, "id", ORGANIZATION_ID);
@@ -489,6 +569,7 @@ class OrganizationServiceTest {
 
     @Test
     @DisplayName("should set NON_COMPLIANT and publish audit when required docs missing")
+    @SuppressWarnings("unchecked")
     void shouldSetNonCompliantWhenRequiredDocsMissing() {
       Organization org = OrganizationFixtures.pendingApproval();
       ReflectionTestUtils.setField(org, "id", ORGANIZATION_ID);
@@ -519,9 +600,8 @@ class OrganizationServiceTest {
 
     @Test
     @DisplayName("should skip audit when compliance status unchanged")
+    @SuppressWarnings("unchecked")
     void shouldSkipWhenStatusUnchanged() {
-      // OrganizationFixtures.active() has NON_COMPLIANT default now
-      // so returning false means no change — no audit event
       Organization org = OrganizationFixtures.active();
       ReflectionTestUtils.setField(org, "id", ORGANIZATION_ID);
 
@@ -532,6 +612,49 @@ class OrganizationServiceTest {
       service.updateComplianceStatus(org);
 
       verify(auditTemplate, never()).execute(any(), any(), any(), any(ThrowingSupplier.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("updateLogoKey")
+  class UpdateLogoKey {
+
+    @Test
+    @DisplayName("should throw ResourceNotFoundException when org does not exist")
+    void shouldThrowWhenOrgNotFound() {
+      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> service.updateLogoKey(ORGANIZATION_ID, "logos/new/logo"))
+          .isInstanceOf(ResourceNotFoundException.class);
+
+      verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("should save new key and return null when no previous key")
+    void shouldSaveNewKeyAndReturnNullWhenNoPreviousKey() {
+      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(repository.save(organization)).thenReturn(organization);
+
+      String previous = service.updateLogoKey(ORGANIZATION_ID, "logos/new/logo");
+
+      assertThat(previous).isNull();
+      verify(repository).save(organization);
+    }
+
+    @Test
+    @DisplayName("should save new key and return previous key when one existed")
+    void shouldSaveNewKeyAndReturnPreviousKey() {
+      String existingKey = "logos/old/logo";
+      ReflectionTestUtils.setField(organization, "logoKey", existingKey);
+
+      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(repository.save(organization)).thenReturn(organization);
+
+      String previous = service.updateLogoKey(ORGANIZATION_ID, "logos/new/logo");
+
+      assertThat(previous).isEqualTo(existingKey);
+      verify(repository).save(organization);
     }
   }
 }

--- a/src/test/java/com/ebikes/organizations/services/organizations/OrganizationServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/organizations/OrganizationServiceTest.java
@@ -1,5 +1,34 @@
 package com.ebikes.organizations.services.organizations;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.models.Address;
@@ -32,34 +61,6 @@ import com.ebikes.organizations.support.fixtures.OrganizationRequestFixtures;
 import com.ebikes.organizations.support.fixtures.SecurityFixtures;
 import com.ebikes.organizations.support.infrastructure.WithExecutionContext;
 import com.ebikes.organizations.support.makerchecker.MakerCheckerTemplate;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @DisplayName("OrganizationService")
 @ExtendWith({MockitoExtension.class, WithExecutionContext.class})


### PR DESCRIPTION
## Purpose
Adds organization logo management to the `ebikes-organizations` service. Organizations can now
upload a logo to S3, confirm the upload, and have a presigned redirect URL served to consumers.
Organization and branch reference DTOs are enriched with `logoUrl` (and `address` for
organizations) so downstream consumers can render branded experiences without additional lookups.

## List of Changes
- Added `POST /organizations/{id}/logo/upload-url`, `PUT /organizations/{id}/logo`, and
  `GET /organizations/{id}/logo` endpoints to `OrganizationController`.
- Introduced `ImageService` encapsulating logo key derivation, MIME type validation, storage
  confirmation, previous logo deletion, and presigned redirect URL generation.
- Added `OrganizationService.updateLogoKey` — persists the new S3 key and returns the previous one
  for cleanup. Visibility of `requireById` widened to `public` to support `ImageService`.
- Added `StorageService.deleteObject` wrapping the AWS SDK v2 `DeleteObjectRequest`.
- Added `toFormattedString()` to the `Address` model for use in reference enrichment.
- Enriched `OrganizationReference` with `address` and `logoUrl` fields; enriched `BranchReference`
  with `logoUrl`.
- Updated `OrganizationMapper` and `BranchMapper` with `toReference` methods accepting the new
  fields.
- Replaced JPA projection queries in `OrganizationRepository` and `BranchRepository` with full
  entity queries to support runtime URL and address resolution.
- Simplified `OrganizationService.handleApprovalDecision` — removed `OrganizationCreatedEvent` and
  `OrganizationUpdatedEvent` outbox publishing from the approval flow; `recordCreateApproval` and
  `recordUpdateApproval` are now `void`.
- Added Liquibase changeset `04-organization-add-logo-key` adding a nullable `logo_key VARCHAR(500)`
  column to `organizations.organizations`.
- Updated deploy script command across `publish-dev.yml`, `publish-staging.yml`, and
  `release-production.yml` from `/usr/local/bin/deploy-application.sh` to `ebikes-deploy-backend`.
- Updated `OrganizationServiceTest` and `BranchServiceTest` for refactored constructor dependencies.
- Updated `OrganizationServiceIT` to reflect removal of `CREATED` event assertion and updated
  maker-checker decision fixture for update approval.
- Added `ImageServiceTest` covering all branches of `generateImageUploadUrl`, `confirmImageUpload`,
  and `generateImageRedirectUrl`.
- Added logo endpoint tests to `OrganizationControllerTest` covering auth enforcement and happy
  paths for all three new endpoints.

## Linked Issues
- #8 

## How to Test
1. Apply the Liquibase migration — it will run automatically on startup; verify the `logo_key`
   column is present on `organizations.organizations`.
2. Run the application with the standard Spring Boot startup command.
3. Obtain a JWT for a user with the `ORGANIZATION_ADMIN` role via Keycloak.
4. Generate an upload URL: