### PR TITLE
feat(notifications): publish ORGANIZATION_WELCOME on organization approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,8 @@ JAVERS_PRETTY_PRINT=false
 JAVERS_SPRING_DATA_AUDITABLE_REPOSITORY_ASPECT_ENABLED=false
 JAVERS_SQL_SCHEMA_MANAGEMENT_ENABLED=false
 JAVERS_TYPE_SAFE_VALUES=false
+
+# =============================================================================
+# Notifications
+# =============================================================================
+NOTIFICATIONS_ENABLED=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:21-jre-alpine@sha256:9f1de3e01a3c43e2f158abf408ec761813da639961bde93427c1ea42a619a09b
+# eclipse-temurin 21-jre-alpine as of 2026-04-09
+FROM eclipse-temurin@sha256:6ad8ed080d9be96b61438ec3ce99388e294af216ed57356000c06070e85c5d5d
 
 RUN apk add --no-cache shadow tzdata
 
@@ -9,10 +10,11 @@ RUN addgroup -S appgroup && \
     mkdir -p /app/logs && \
     chown -R appuser:appgroup /app
 
-COPY --chown=appuser:appgroup dependencies/ ./
-COPY --chown=appuser:appgroup spring-boot-loader/ ./
-COPY --chown=appuser:appgroup snapshot-dependencies*/ ./
-COPY --chown=appuser:appgroup application/ ./
+COPY --chown=appuser:appgroup --chmod=550 dependencies/ ./
+COPY --chown=appuser:appgroup --chmod=550 spring-boot-loader/ ./
+COPY --chown=appuser:appgroup --chmod=550 snapshot-dependencies*/ ./
+COPY --chown=appuser:appgroup --chmod=550 application/ ./
+
 
 ENV TZ=Africa/Nairobi
 
@@ -27,7 +29,7 @@ ARG VERSION
 ARG BUILD_DATE
 ARG VCS_REF
 
-LABEL org.opencontainers.image.title="eBikes Africa organizations service"
+LABEL org.opencontainers.image.title="Ebikes Africa organizations service"
 LABEL org.opencontainers.image.description=""
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"

--- a/src/main/java/com/ebikes/organizations/configurations/properties/NotificationProperties.java
+++ b/src/main/java/com/ebikes/organizations/configurations/properties/NotificationProperties.java
@@ -1,0 +1,16 @@
+package com.ebikes.organizations.configurations.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Data;
+
+@ConfigurationProperties(prefix = "notifications")
+@Component
+@Data
+@Validated
+public class NotificationProperties {
+
+  private boolean enabled = true;
+}

--- a/src/main/java/com/ebikes/organizations/constants/EventConstants.java
+++ b/src/main/java/com/ebikes/organizations/constants/EventConstants.java
@@ -6,6 +6,19 @@ public final class EventConstants {
 
   private EventConstants() {}
 
+  public static final class RoutingKeys {
+
+    private RoutingKeys() {}
+
+    public static final String NOTIFICATIONS_EMAIL = "notifications.email";
+    public static final String NOTIFICATIONS_SMS = "notifications.sms";
+    public static final String NOTIFICATIONS_SSE = "notifications.sse";
+    public static final String NOTIFICATIONS_WHATSAPP = "notifications.whatsapp";
+
+    public static final String ORGANIZATIONS_ORGANIZATION_CREATED =
+        Source.ORGANIZATIONS + ".organization.created";
+  }
+
   public static final class Source {
 
     private Source() {}
@@ -61,14 +74,5 @@ public final class EventConstants {
 
     // inbound — maker-checker decisions arrive as maker-checker.organization.<outcome>
     public static final String MAKER_CHECKER_ORGANIZATION = "maker-checker.organization";
-  }
-
-  public static final class MessageHeaders {
-
-    private MessageHeaders() {}
-
-    public static final String EVENT_TYPE = "eventType";
-    public static final String OUTBOX_ID = "outboxId";
-    public static final String ROUTING_KEY = "routingKey";
   }
 }

--- a/src/main/java/com/ebikes/organizations/dtos/events/outgoing/NotificationRequest.java
+++ b/src/main/java/com/ebikes/organizations/dtos/events/outgoing/NotificationRequest.java
@@ -1,0 +1,35 @@
+package com.ebikes.organizations.dtos.events.outgoing;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Map;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import com.ebikes.organizations.enums.ChannelType;
+import com.ebikes.organizations.enums.NotificationCategory;
+
+public record NotificationRequest(
+    String branchId,
+    @NotNull NotificationCategory category,
+    @NotNull ChannelType channel,
+    @NotBlank String eventType,
+    @NotBlank String organizationId,
+    @NotBlank String recipient,
+    @NotBlank String serviceReference,
+    String subjectUserId,
+    @Pattern(
+            regexp = "^[A-Z][A-Z0-9_]{2,99}$",
+            message = "Template name must be SCREAMING_SNAKE_CASE")
+        String templateName,
+    Instant timestamp,
+    Map<String, Serializable> variables)
+    implements Serializable {
+
+  public NotificationRequest {
+    timestamp = timestamp != null ? timestamp : Instant.now();
+    variables = variables != null ? Map.copyOf(variables) : Map.of();
+  }
+}

--- a/src/main/java/com/ebikes/organizations/enums/ChannelType.java
+++ b/src/main/java/com/ebikes/organizations/enums/ChannelType.java
@@ -1,0 +1,8 @@
+package com.ebikes.organizations.enums;
+
+public enum ChannelType {
+  EMAIL,
+  SMS,
+  SSE,
+  WHATSAPP
+}

--- a/src/main/java/com/ebikes/organizations/enums/NotificationCategory.java
+++ b/src/main/java/com/ebikes/organizations/enums/NotificationCategory.java
@@ -1,0 +1,8 @@
+package com.ebikes.organizations.enums;
+
+public enum NotificationCategory {
+  MARKETING,
+  OPERATIONAL,
+  SECURITY,
+  TRANSACTIONAL
+}

--- a/src/main/java/com/ebikes/organizations/mappers/NotificationMapper.java
+++ b/src/main/java/com/ebikes/organizations/mappers/NotificationMapper.java
@@ -1,0 +1,24 @@
+package com.ebikes.organizations.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+  @Mapping(target = "branchId", ignore = true)
+  @Mapping(target = "category", constant = "OPERATIONAL")
+  @Mapping(target = "channel", constant = "EMAIL")
+  @Mapping(target = "eventType", constant = "ORGANIZATION_WELCOME")
+  @Mapping(target = "organizationId", expression = "java(organization.getId().toString())")
+  @Mapping(target = "recipient", source = "organization.email")
+  @Mapping(target = "serviceReference", source = "serviceReference")
+  @Mapping(target = "subjectUserId", source = "organization.ownerId")
+  @Mapping(target = "templateName", constant = "ORGANIZATION_WELCOME")
+  @Mapping(target = "timestamp", ignore = true)
+  @Mapping(target = "variables", ignore = true)
+  NotificationRequest toOrganizationWelcome(Organization organization, String serviceReference);
+}

--- a/src/main/java/com/ebikes/organizations/publishers/AuditEventPublisher.java
+++ b/src/main/java/com/ebikes/organizations/publishers/AuditEventPublisher.java
@@ -17,10 +17,10 @@ public class AuditEventPublisher {
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void publishFailure(AuditEvent event, String routingKey) {
-    outboxService.save(event.eventType(), event, routingKey);
+    outboxService.publish(event.eventType(), event, routingKey);
   }
 
   public void publishSuccess(AuditEvent event, String routingKey) {
-    outboxService.save(event.eventType(), event, routingKey);
+    outboxService.publish(event.eventType(), event, routingKey);
   }
 }

--- a/src/main/java/com/ebikes/organizations/publishers/MakerCheckerRequestPublisher.java
+++ b/src/main/java/com/ebikes/organizations/publishers/MakerCheckerRequestPublisher.java
@@ -22,7 +22,7 @@ public class MakerCheckerRequestPublisher {
         request.entityId(),
         request.makerId());
 
-    outboxService.save(request.entityType(), request, routingKey);
+    outboxService.publish(request.entityType(), request, routingKey);
 
     log.info(
         "Maker-checker request queued: entityType={}, entityId={}",

--- a/src/main/java/com/ebikes/organizations/publishers/NotificationEventPublisher.java
+++ b/src/main/java/com/ebikes/organizations/publishers/NotificationEventPublisher.java
@@ -1,0 +1,44 @@
+package com.ebikes.organizations.publishers;
+
+import org.springframework.stereotype.Component;
+
+import com.ebikes.organizations.configurations.properties.NotificationProperties;
+import com.ebikes.organizations.constants.EventConstants.RoutingKeys;
+import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
+import com.ebikes.organizations.enums.ChannelType;
+import com.ebikes.organizations.services.events.OutboxService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationEventPublisher {
+
+  private final OutboxService outboxService;
+  private final NotificationProperties notificationProperties;
+
+  public void publish(NotificationRequest request) {
+    String routingKey = resolveRoutingKey(request.channel());
+    if (notificationProperties.isEnabled()) {
+      outboxService.publish(request.eventType(), request, routingKey);
+      log.info(
+          "Notification event queued - eventType={} channel={} recipient={}",
+          request.eventType(),
+          request.channel(),
+          request.recipient());
+    } else {
+      log.info("Notification service is disabled");
+    }
+  }
+
+  private String resolveRoutingKey(ChannelType channel) {
+    return switch (channel) {
+      case EMAIL -> RoutingKeys.NOTIFICATIONS_EMAIL;
+      case SMS -> RoutingKeys.NOTIFICATIONS_SMS;
+      case SSE -> RoutingKeys.NOTIFICATIONS_SSE;
+      case WHATSAPP -> RoutingKeys.NOTIFICATIONS_WHATSAPP;
+    };
+  }
+}

--- a/src/main/java/com/ebikes/organizations/services/events/OutboxEventProcessor.java
+++ b/src/main/java/com/ebikes/organizations/services/events/OutboxEventProcessor.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ebikes.organizations.constants.ApplicationConstants;
-import com.ebikes.organizations.constants.EventConstants.MessageHeaders;
+import com.ebikes.organizations.constants.ApplicationConstants.MessageHeaders;
 import com.ebikes.organizations.database.entities.Outbox;
 import com.ebikes.organizations.database.repositories.OutboxRepository;
 

--- a/src/main/java/com/ebikes/organizations/services/events/OutboxService.java
+++ b/src/main/java/com/ebikes/organizations/services/events/OutboxService.java
@@ -56,7 +56,7 @@ public class OutboxService {
   }
 
   @Transactional
-  public void save(String eventType, Object payload, String routingKey) {
+  public void publish(String eventType, Object payload, String routingKey) {
     Outbox outbox =
         Outbox.builder().eventType(eventType).payload(payload).routingKey(routingKey).build();
 

--- a/src/main/java/com/ebikes/organizations/services/notifications/NotificationService.java
+++ b/src/main/java/com/ebikes/organizations/services/notifications/NotificationService.java
@@ -1,0 +1,28 @@
+package com.ebikes.organizations.services.notifications;
+
+import org.springframework.stereotype.Service;
+
+import com.ebikes.organizations.constants.EventConstants.Source;
+import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
+import com.ebikes.organizations.mappers.NotificationMapper;
+import com.ebikes.organizations.publishers.NotificationEventPublisher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class NotificationService {
+
+  private final NotificationEventPublisher notificationEventPublisher;
+  private final NotificationMapper notificationMapper;
+
+  public void sendOrganizationWelcome(Organization organization) {
+    NotificationRequest request =
+        notificationMapper.toOrganizationWelcome(organization, Source.serviceReference());
+    notificationEventPublisher.publish(request);
+    log.info("Organization welcome notification queued: organizationId={}", organization.getId());
+  }
+}

--- a/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
+++ b/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
+import com.ebikes.organizations.constants.EventConstants.RoutingKeys;
+import com.ebikes.organizations.constants.EventConstants.Source;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.repositories.OrganizationRepository;
 import com.ebikes.organizations.database.specifications.OrganizationSpecifications;
@@ -26,9 +28,12 @@ import com.ebikes.organizations.enums.ComplianceStatus;
 import com.ebikes.organizations.enums.ResponseCode;
 import com.ebikes.organizations.exceptions.DuplicateResourceException;
 import com.ebikes.organizations.exceptions.ResourceNotFoundException;
+import com.ebikes.organizations.mappers.EventMapper;
 import com.ebikes.organizations.mappers.OrganizationMapper;
 import com.ebikes.organizations.services.branches.BranchService;
 import com.ebikes.organizations.services.documents.DocumentService;
+import com.ebikes.organizations.services.events.OutboxService;
+import com.ebikes.organizations.services.notifications.NotificationService;
 import com.ebikes.organizations.services.storage.StorageService;
 import com.ebikes.organizations.support.audit.AuditTemplate;
 import com.ebikes.organizations.support.changes.ChangeApplier;
@@ -51,9 +56,12 @@ public class OrganizationService {
   private final BranchService branchService;
   private final ChangeApplier changeApplier;
   private final DocumentService documentService;
+  private final EventMapper eventMapper;
   private final MakerCheckerTemplate makerCheckerTemplate;
+  private final NotificationService notificationService;
   private final OrganizationMapper organizationMapper;
   private final OrganizationRepository repository;
+  private final OutboxService outboxService;
   private final SnapshotCreator snapshotCreator;
   private final StorageService storageService;
 
@@ -270,6 +278,11 @@ public class OrganizationService {
             () -> repository.save(organization));
 
     branchService.createDefaultBranch(approved);
+    notificationService.sendOrganizationWelcome(approved);
+    outboxService.publish(
+        DomainEvents.Organization.CREATED,
+        eventMapper.toOrganizationCreatedEvent(approved, Source.serviceReference()),
+        RoutingKeys.ORGANIZATIONS_ORGANIZATION_CREATED);
     log.info(
         "Organization creation approved and activated: organizationId={}", organization.getId());
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -138,6 +138,9 @@ management:
       exposure:
         include: health,info,metrics,prometheus
 
+notifications:
+  enabled: ${NOTIFICATIONS_ENABLED}
+
 security:
   public-endpoints:
     - /actuator/health

--- a/src/test/java/com/ebikes/organizations/integration/services/organizations/OrganizationServiceIT.java
+++ b/src/test/java/com/ebikes/organizations/integration/services/organizations/OrganizationServiceIT.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
+import com.ebikes.organizations.constants.EventConstants.RoutingKeys;
 import com.ebikes.organizations.database.entities.Document;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.models.Address;
@@ -406,7 +407,12 @@ class OrganizationServiceIT extends AbstractIntegrationTest {
             outboxRepository.findAll();
         assertThat(outboxRecords)
             .hasSizeGreaterThanOrEqualTo(2)
-            .anyMatch(o -> o.getEventType().equals(DomainEvents.Organization.APPROVED));
+            .anyMatch(o -> o.getEventType().equals(DomainEvents.Organization.APPROVED))
+            .anyMatch(
+                o ->
+                    o.getEventType().equals(DomainEvents.Organization.CREATED)
+                        && o.getRoutingKey()
+                            .equals(RoutingKeys.ORGANIZATIONS_ORGANIZATION_CREATED));
       }
 
       @Test

--- a/src/test/java/com/ebikes/organizations/publishers/AuditEventPublisherTest.java
+++ b/src/test/java/com/ebikes/organizations/publishers/AuditEventPublisherTest.java
@@ -54,7 +54,7 @@ class AuditEventPublisherTest {
 
       publisher.publishSuccess(auditEvent, ROUTING_KEY);
 
-      verify(outboxService).save(EVENT_TYPE, auditEvent, ROUTING_KEY);
+      verify(outboxService).publish(EVENT_TYPE, auditEvent, ROUTING_KEY);
     }
   }
 
@@ -69,7 +69,7 @@ class AuditEventPublisherTest {
 
       publisher.publishFailure(auditEvent, ROUTING_KEY);
 
-      verify(outboxService).save(EVENT_TYPE, auditEvent, ROUTING_KEY);
+      verify(outboxService).publish(EVENT_TYPE, auditEvent, ROUTING_KEY);
     }
   }
 }

--- a/src/test/java/com/ebikes/organizations/publishers/MakerCheckerRequestPublisherTest.java
+++ b/src/test/java/com/ebikes/organizations/publishers/MakerCheckerRequestPublisherTest.java
@@ -50,6 +50,6 @@ class MakerCheckerRequestPublisherTest {
 
     publisher.publish(makerCheckerRequest, ROUTING_KEY);
 
-    verify(outboxService).save(ENTITY_TYPE, makerCheckerRequest, ROUTING_KEY);
+    verify(outboxService).publish(ENTITY_TYPE, makerCheckerRequest, ROUTING_KEY);
   }
 }

--- a/src/test/java/com/ebikes/organizations/services/branches/BranchAddressServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/branches/BranchAddressServiceTest.java
@@ -52,7 +52,7 @@ class BranchAddressServiceTest {
   class Create {
 
     @Test
-    @DisplayName("should build BranchAddress with BRANCH_LOCATION tag from request and save")
+    @DisplayName("should build BranchAddress with BRANCH_LOCATION tag from request and publish")
     void shouldCreateBranchAddressFromRequest() {
       BranchAddressRequest request =
           new BranchAddressRequest("Nairobi", "Kenya", null, null, "00100", "123 Main St");
@@ -78,7 +78,7 @@ class BranchAddressServiceTest {
   class CreateFromOrganizationAddress {
 
     @Test
-    @DisplayName("should map Address fields to BranchAddress with BRANCH_LOCATION tag and save")
+    @DisplayName("should map Address fields to BranchAddress with BRANCH_LOCATION tag and publish")
     void shouldCreateBranchAddressFromOrganizationAddress() {
       Address address =
           new Address(
@@ -149,7 +149,7 @@ class BranchAddressServiceTest {
   class Update {
 
     @Test
-    @DisplayName("should find existing address, call update, and save")
+    @DisplayName("should find existing address, call update, and publish")
     void shouldUpdateBranchAddress() {
       BranchAddressRequest request =
           new BranchAddressRequest("Mombasa", "Kenya", null, null, "80100", "456 New St");

--- a/src/test/java/com/ebikes/organizations/services/documents/DocumentServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/documents/DocumentServiceTest.java
@@ -121,7 +121,7 @@ class DocumentServiceTest {
   class ActivateDocuments {
 
     @Test
-    @DisplayName("should activate all uploaded documents and save")
+    @DisplayName("should activate all uploaded documents and publish")
     void shouldActivateAllUploadedDocumentsAndSave() {
       Document uploaded = DocumentFixtures.uploaded(organization);
       when(documentRepository.findByOrganizationIdAndStatus(
@@ -152,7 +152,7 @@ class DocumentServiceTest {
   class Archive {
 
     @Test
-    @DisplayName("should archive all stale uploaded documents and save")
+    @DisplayName("should archive all stale uploaded documents and publish")
     @SuppressWarnings("unchecked")
     void shouldArchiveAllDocumentsAndSave() {
       Document uploaded = DocumentFixtures.uploaded(organization);
@@ -186,7 +186,7 @@ class DocumentServiceTest {
   class Expire {
 
     @Test
-    @DisplayName("should expire all documents and save")
+    @DisplayName("should expire all documents and publish")
     @SuppressWarnings("unchecked")
     void shouldExpireAllDocumentsAndSave() {
       Document active = DocumentFixtures.active(organization);
@@ -221,7 +221,7 @@ class DocumentServiceTest {
   class AssociateWithOrganization {
 
     @Test
-    @DisplayName("should associate documents and save")
+    @DisplayName("should associate documents and publish")
     void shouldAssociateDocumentsAndSave() {
       Document document = DocumentFixtures.pending(organization);
       when(documentRepository.findAllByFileStorageUrlIn(List.of(STORAGE_KEY)))
@@ -355,7 +355,7 @@ class DocumentServiceTest {
   class ConfirmReplacement {
 
     @Test
-    @DisplayName("should mark replacement document as uploaded and save")
+    @DisplayName("should mark replacement document as uploaded and publish")
     void shouldMarkUploadedAndSave() {
       Document original = DocumentFixtures.active(organization);
       Document replacement = DocumentFixtures.pending(organization);

--- a/src/test/java/com/ebikes/organizations/services/events/InboxServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/events/InboxServiceTest.java
@@ -43,7 +43,7 @@ class InboxServiceTest {
   class MarkProcessed {
 
     @Test
-    @DisplayName("should mark inbox as processed and save")
+    @DisplayName("should mark inbox as processed and publish")
     void shouldMarkProcessedAndSave() {
       Inbox inbox = new Inbox(EVENT_TYPE, SERVICE_REFERENCE, SOURCE_CONTEXT);
       when(inboxRepository.findById(SERVICE_REFERENCE)).thenReturn(Optional.of(inbox));
@@ -70,7 +70,7 @@ class InboxServiceTest {
   class Receive {
 
     @Test
-    @DisplayName("should save inbox record and return true")
+    @DisplayName("should publish inbox record and return true")
     void shouldSaveAndReturnTrue() {
       when(inboxRepository.save(any(Inbox.class)))
           .thenAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/ebikes/organizations/services/events/OutboxEventProcessorTest.java
+++ b/src/test/java/com/ebikes/organizations/services/events/OutboxEventProcessorTest.java
@@ -52,7 +52,7 @@ class OutboxEventProcessorTest {
   class WhenSendSucceeds {
 
     @Test
-    @DisplayName("should mark outbox as SENT and save")
+    @DisplayName("should mark outbox as SENT and publish")
     void shouldMarkSentAndSave() {
       Outbox outbox = OutboxFixtures.pending(EVENT_TYPE);
       when(streamBridge.send(eq(BINDING_NAME), any())).thenReturn(true);
@@ -80,7 +80,7 @@ class OutboxEventProcessorTest {
   class WhenSendReturnsFalse {
 
     @Test
-    @DisplayName("should mark outbox as FAILED and save")
+    @DisplayName("should mark outbox as FAILED and publish")
     void shouldMarkFailedAndSave() {
       Outbox outbox = OutboxFixtures.pending(EVENT_TYPE);
       when(streamBridge.send(eq(BINDING_NAME), any())).thenReturn(false);
@@ -111,7 +111,7 @@ class OutboxEventProcessorTest {
   class WhenSendThrows {
 
     @Test
-    @DisplayName("should mark outbox as FAILED and save")
+    @DisplayName("should mark outbox as FAILED and publish")
     void shouldMarkFailedAndSave() {
       Outbox outbox = OutboxFixtures.pending(EVENT_TYPE);
       doThrow(new RuntimeException("broker unavailable"))

--- a/src/test/java/com/ebikes/organizations/services/events/OutboxServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/events/OutboxServiceTest.java
@@ -65,7 +65,7 @@ class OutboxServiceTest {
   class Retry {
 
     @Test
-    @DisplayName("should reset outbox to PENDING and save")
+    @DisplayName("should reset outbox to PENDING and publish")
     void shouldResetToPendingAndSave() {
       Outbox outbox = OutboxFixtures.failed("ORGANIZATION_CREATED");
       when(repository.findById(OUTBOX_ID)).thenReturn(Optional.of(outbox));
@@ -91,7 +91,7 @@ class OutboxServiceTest {
   class RetryAllFailed {
 
     @Test
-    @DisplayName("should reset all failed events to PENDING and save")
+    @DisplayName("should reset all failed events to PENDING and publish")
     void shouldResetAllFailedAndSave() {
       Outbox first = OutboxFixtures.failed("ORGANIZATION_CREATED");
       Outbox second = OutboxFixtures.failed("USER_UPDATED");
@@ -119,13 +119,13 @@ class OutboxServiceTest {
   }
 
   @Nested
-  @DisplayName("save")
+  @DisplayName("publish")
   class Save {
 
     @Test
     @DisplayName("should build and persist outbox with correct fields")
     void shouldBuildAndPersistOutbox() {
-      service.save(
+      service.publish(
           "ORGANIZATION_CREATED", EventFixtures.organizationCreatedEvent(), "test.routing.key");
 
       verify(repository).save(any(Outbox.class));

--- a/src/test/java/com/ebikes/organizations/services/notifications/NotificationServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/notifications/NotificationServiceTest.java
@@ -1,0 +1,70 @@
+package com.ebikes.organizations.services.notifications;
+
+import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
+import com.ebikes.organizations.enums.ChannelType;
+import com.ebikes.organizations.mappers.NotificationMapper;
+import com.ebikes.organizations.publishers.NotificationEventPublisher;
+import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
+import com.ebikes.organizations.support.fixtures.SecurityFixtures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("NotificationService")
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  private static final UUID ORGANIZATION_ID =
+      UUID.fromString(SecurityFixtures.TEST_ORGANIZATION_ID);
+
+  @Mock private NotificationEventPublisher notificationEventPublisher;
+  @Mock private NotificationMapper notificationMapper;
+
+  private NotificationService service;
+  private Organization organization;
+
+  @BeforeEach
+  void setUp() {
+    service = new NotificationService(notificationEventPublisher, notificationMapper);
+    organization = OrganizationFixtures.active();
+    ReflectionTestUtils.setField(organization, "id", ORGANIZATION_ID);
+  }
+
+  @Test
+  @DisplayName("should map organization to NotificationRequest and delegate to publisher")
+  void shouldMapAndPublish() {
+    NotificationRequest request =
+        new NotificationRequest(
+            null,
+            null,
+            ChannelType.EMAIL,
+            "ORGANIZATION_WELCOME",
+            ORGANIZATION_ID.toString(),
+            organization.getEmail(),
+            "any-reference",
+            organization.getOwnerId(),
+            "ORGANIZATION_WELCOME",
+            null,
+            null);
+
+    when(notificationMapper.toOrganizationWelcome(eq(organization), any(String.class)))
+        .thenReturn(request);
+
+    service.sendOrganizationWelcome(organization);
+
+    verify(notificationMapper).toOrganizationWelcome(eq(organization), any(String.class));
+    verify(notificationEventPublisher).publish(request);
+  }
+}

--- a/src/test/java/com/ebikes/organizations/services/notifications/NotificationServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/notifications/NotificationServiceTest.java
@@ -1,12 +1,12 @@
 package com.ebikes.organizations.services.notifications;
 
-import com.ebikes.organizations.database.entities.Organization;
-import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
-import com.ebikes.organizations.enums.ChannelType;
-import com.ebikes.organizations.mappers.NotificationMapper;
-import com.ebikes.organizations.publishers.NotificationEventPublisher;
-import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
-import com.ebikes.organizations.support.fixtures.SecurityFixtures;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,12 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.ebikes.organizations.database.entities.Organization;
+import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
+import com.ebikes.organizations.enums.ChannelType;
+import com.ebikes.organizations.mappers.NotificationMapper;
+import com.ebikes.organizations.publishers.NotificationEventPublisher;
+import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
+import com.ebikes.organizations.support.fixtures.SecurityFixtures;
 
 @DisplayName("NotificationService")
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/ebikes/organizations/services/organizations/OrganizationServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/organizations/OrganizationServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.ebikes.organizations.constants.EventConstants.DomainEvents;
+import com.ebikes.organizations.constants.EventConstants.RoutingKeys;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.database.models.Address;
 import com.ebikes.organizations.database.repositories.OrganizationRepository;
@@ -46,9 +47,12 @@ import com.ebikes.organizations.enums.FieldType;
 import com.ebikes.organizations.enums.OrganizationStatus;
 import com.ebikes.organizations.exceptions.DuplicateResourceException;
 import com.ebikes.organizations.exceptions.ResourceNotFoundException;
+import com.ebikes.organizations.mappers.EventMapper;
 import com.ebikes.organizations.mappers.OrganizationMapper;
 import com.ebikes.organizations.services.branches.BranchService;
 import com.ebikes.organizations.services.documents.DocumentService;
+import com.ebikes.organizations.services.events.OutboxService;
+import com.ebikes.organizations.services.notifications.NotificationService;
 import com.ebikes.organizations.services.storage.StorageService;
 import com.ebikes.organizations.support.audit.AuditTemplate;
 import com.ebikes.organizations.support.audit.ThrowingRunnable;
@@ -74,9 +78,12 @@ class OrganizationServiceTest {
   @Mock private BranchService branchService;
   @Mock private ChangeApplier changeApplier;
   @Mock private DocumentService documentService;
+  @Mock private EventMapper eventMapper;
   @Mock private MakerCheckerTemplate makerCheckerTemplate;
+  @Mock private NotificationService notificationService;
   @Mock private OrganizationMapper organizationMapper;
-  @Mock private OrganizationRepository repository;
+  @Mock private OrganizationRepository organizationRepository;
+  @Mock private OutboxService outboxService;
   @Mock private SnapshotCreator snapshotCreator;
   @Mock private StorageService storageService;
 
@@ -91,9 +98,12 @@ class OrganizationServiceTest {
             branchService,
             changeApplier,
             documentService,
+            eventMapper,
             makerCheckerTemplate,
+            notificationService,
             organizationMapper,
-            repository,
+            organizationRepository,
+            outboxService,
             snapshotCreator,
             storageService);
 
@@ -119,15 +129,15 @@ class OrganizationServiceTest {
 
     @Test
     @DisplayName(
-        "should save organization, associate documents, re-fetch, publish maker-checker, return"
+        "should publish organization, associate documents, re-fetch, publish maker-checker, return"
             + " organization")
     void shouldCreateOrganizationSuccessfully() {
       List<FieldChange> snapshot =
           List.of(new FieldChange("legalName", FieldType.STRING, "Test Organization Ltd", null));
 
-      when(repository.existsByLegalName(any())).thenReturn(false);
-      when(repository.save(any(Organization.class))).thenReturn(organization);
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(organizationRepository.existsByLegalName(any())).thenReturn(false);
+      when(organizationRepository.save(any(Organization.class))).thenReturn(organization);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
       when(snapshotCreator.extractFields(organization)).thenReturn(snapshot);
 
       Organization result = service.create(OrganizationRequestFixtures.create());
@@ -142,7 +152,7 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("should throw DuplicateResourceException when legal name already exists")
     void shouldThrowWhenLegalNameDuplicate() {
-      when(repository.existsByLegalName(any())).thenReturn(true);
+      when(organizationRepository.existsByLegalName(any())).thenReturn(true);
 
       CreateOrganizationRequest request = OrganizationRequestFixtures.create();
       assertThatThrownBy(() -> service.create(request))
@@ -161,8 +171,8 @@ class OrganizationServiceTest {
       Organization active = OrganizationFixtures.active();
       ReflectionTestUtils.setField(active, "id", ORGANIZATION_ID);
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(active));
-      when(repository.save(any(Organization.class))).thenReturn(active);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(active));
+      when(organizationRepository.save(any(Organization.class))).thenReturn(active);
       stubAuditExecute(active);
 
       Organization result = service.deactivate(ORGANIZATION_ID, "test reason");
@@ -179,7 +189,7 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("should throw ResourceNotFoundException when organization not found")
     void shouldThrowWhenNotFound() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
 
       assertThatThrownBy(() -> service.deactivate(ORGANIZATION_ID, "reason"))
           .isInstanceOf(ResourceNotFoundException.class);
@@ -193,7 +203,7 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("should return organization when found")
     void shouldReturnOrganizationWhenFound() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
 
       assertThat(service.findById(ORGANIZATION_ID)).isEqualTo(organization);
     }
@@ -201,7 +211,7 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("should throw ResourceNotFoundException when not found")
     void shouldThrowWhenNotFound() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
 
       assertThatThrownBy(() -> service.findById(ORGANIZATION_ID))
           .isInstanceOf(ResourceNotFoundException.class);
@@ -223,7 +233,7 @@ class OrganizationServiceTest {
           new OrganizationReference(
               ORGANIZATION_ID, null, organization.getDisplayName(), presignedUrl);
 
-      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationRepository.findByIdIn(ids)).thenReturn(List.of(organization));
       when(storageService.generatePreviewUrl(eq(logoKey), any())).thenReturn(presignedUrl);
       when(organizationMapper.toReference(organization, null, presignedUrl)).thenReturn(reference);
 
@@ -238,7 +248,7 @@ class OrganizationServiceTest {
       OrganizationReference reference =
           new OrganizationReference(ORGANIZATION_ID, null, organization.getDisplayName(), null);
 
-      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationRepository.findByIdIn(ids)).thenReturn(List.of(organization));
       when(organizationMapper.toReference(organization, null, null)).thenReturn(reference);
 
       assertThat(service.findReferencesByIds(ids)).containsExactly(reference);
@@ -264,7 +274,7 @@ class OrganizationServiceTest {
           new OrganizationReference(
               ORGANIZATION_ID, formattedAddress, organization.getDisplayName(), null);
 
-      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationRepository.findByIdIn(ids)).thenReturn(List.of(organization));
       when(organizationMapper.toReference(organization, formattedAddress, null))
           .thenReturn(reference);
 
@@ -278,7 +288,7 @@ class OrganizationServiceTest {
       OrganizationReference reference =
           new OrganizationReference(ORGANIZATION_ID, null, organization.getDisplayName(), null);
 
-      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationRepository.findByIdIn(ids)).thenReturn(List.of(organization));
       when(organizationMapper.toReference(organization, null, null)).thenReturn(reference);
 
       service.findReferencesByIds(ids);
@@ -293,7 +303,7 @@ class OrganizationServiceTest {
       OrganizationReference reference =
           new OrganizationReference(ORGANIZATION_ID, null, organization.getDisplayName(), null);
 
-      when(repository.findByIdIn(ids)).thenReturn(List.of(organization));
+      when(organizationRepository.findByIdIn(ids)).thenReturn(List.of(organization));
       when(organizationMapper.toReference(organization, null, null)).thenReturn(reference);
 
       assertThat(service.findReferencesByIds(ids)).containsExactly(reference);
@@ -306,7 +316,8 @@ class OrganizationServiceTest {
 
     @Test
     @DisplayName(
-        "CREATE APPROVED — validates documents, activates, approves, creates default branch")
+        "CREATE APPROVED → validates documents, activates, approves, creates default branch, sends"
+            + " welcome, publishes created event")
     @SuppressWarnings("unchecked")
     void shouldHandleCreateApproved() {
       Organization pending = OrganizationFixtures.pendingApproval();
@@ -314,8 +325,8 @@ class OrganizationServiceTest {
       Organization approved = OrganizationFixtures.active();
       ReflectionTestUtils.setField(approved, "id", ORGANIZATION_ID);
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
-      when(repository.save(any(Organization.class))).thenReturn(approved);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
+      when(organizationRepository.save(any(Organization.class))).thenReturn(approved);
       stubAuditExecute(approved);
 
       service.handleApprovalDecision(
@@ -332,6 +343,12 @@ class OrganizationServiceTest {
               eq(DomainEvents.Organization.APPROVED),
               any(ThrowingSupplier.class));
       verify(branchService).createDefaultBranch(approved);
+      verify(notificationService).sendOrganizationWelcome(approved);
+      verify(outboxService)
+          .publish(
+              eq(DomainEvents.Organization.CREATED),
+              any(),
+              eq(RoutingKeys.ORGANIZATIONS_ORGANIZATION_CREATED));
     }
 
     @Test
@@ -343,8 +360,8 @@ class OrganizationServiceTest {
       Organization rejected = OrganizationFixtures.rejected("not compliant");
       ReflectionTestUtils.setField(rejected, "id", ORGANIZATION_ID);
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
-      when(repository.save(any(Organization.class))).thenReturn(rejected);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
+      when(organizationRepository.save(any(Organization.class))).thenReturn(rejected);
       stubAuditExecute(rejected);
 
       service.handleApprovalDecision(
@@ -371,8 +388,8 @@ class OrganizationServiceTest {
       List<FieldChange> changes =
           List.of(new FieldChange("legalName", FieldType.STRING, "New Name Ltd", "Old Name Ltd"));
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
-      when(repository.save(any(Organization.class))).thenReturn(approved);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
+      when(organizationRepository.save(any(Organization.class))).thenReturn(approved);
       stubAuditExecute(approved);
 
       service.handleApprovalDecision(
@@ -396,8 +413,8 @@ class OrganizationServiceTest {
       Organization rejected = OrganizationFixtures.rejected("invalid documents");
       ReflectionTestUtils.setField(rejected, "id", ORGANIZATION_ID);
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
-      when(repository.save(any(Organization.class))).thenReturn(rejected);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(pending));
+      when(organizationRepository.save(any(Organization.class))).thenReturn(rejected);
       stubAuditExecute(rejected);
 
       service.handleApprovalDecision(
@@ -416,7 +433,7 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("unknown operation — throws IllegalArgumentException")
     void shouldThrowOnUnknownOperation() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
 
       MakerCheckerDecision unknown =
           MakerCheckerFixtures.approved(ORGANIZATION_ID, ENTITY_TYPE, "UNKNOWN_OP");
@@ -428,7 +445,7 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("organization not found — throws ResourceNotFoundException")
     void shouldThrowWhenOrganizationNotFound() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
 
       MakerCheckerDecision decision =
           MakerCheckerFixtures.approved(ORGANIZATION_ID, ENTITY_TYPE, "CREATE");
@@ -449,12 +466,13 @@ class OrganizationServiceTest {
       ReflectionTestUtils.setField(active, "id", ORGANIZATION_ID);
       Page<Organization> page = new PageImpl<>(List.of(active));
 
-      when(repository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+      when(organizationRepository.findAll(any(Specification.class), any(Pageable.class)))
+          .thenReturn(page);
 
       Page<Organization> result = service.search(new OrganizationFilter());
 
       assertThat(result.getContent()).containsExactly(active);
-      verify(repository).findAll(any(Specification.class), any(Pageable.class));
+      verify(organizationRepository).findAll(any(Specification.class), any(Pageable.class));
     }
   }
 
@@ -464,7 +482,7 @@ class OrganizationServiceTest {
 
     @Test
     @DisplayName(
-        "should detect changes, resubmit, save, publish maker-checker, return organization")
+        "should detect changes, resubmit, publish, publish maker-checker, return organization")
     void shouldUpdateOrganizationSuccessfully() {
       Organization existing = OrganizationFixtures.rejected("old rejection");
       ReflectionTestUtils.setField(existing, "id", ORGANIZATION_ID);
@@ -476,9 +494,9 @@ class OrganizationServiceTest {
 
       UpdateOrganizationRequest request = OrganizationRequestFixtures.update("New Legal Name Ltd");
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
-      when(repository.existsByLegalName(request.legalName())).thenReturn(false);
-      when(repository.save(any(Organization.class))).thenReturn(existing);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
+      when(organizationRepository.existsByLegalName(request.legalName())).thenReturn(false);
+      when(organizationRepository.save(any(Organization.class))).thenReturn(existing);
       when(snapshotCreator.extractChanges(any(), any())).thenReturn(changes);
 
       Organization result = service.update(ORGANIZATION_ID, request);
@@ -495,20 +513,20 @@ class OrganizationServiceTest {
 
       UpdateOrganizationRequest request = OrganizationRequestFixtures.update();
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
-      when(repository.existsByLegalName(anyString())).thenReturn(false);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
+      when(organizationRepository.existsByLegalName(anyString())).thenReturn(false);
 
       Organization result = service.update(ORGANIZATION_ID, request);
 
       assertThat(result).isEqualTo(existing);
       verify(makerCheckerTemplate, never()).publish(any(), any(), any(), anyList());
-      verify(repository, never()).save(any());
+      verify(organizationRepository, never()).save(any());
     }
 
     @Test
     @DisplayName("should throw ResourceNotFoundException when organization not found")
     void shouldThrowWhenNotFound() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
 
       UpdateOrganizationRequest request = OrganizationRequestFixtures.update();
 
@@ -525,8 +543,8 @@ class OrganizationServiceTest {
       UpdateOrganizationRequest request =
           OrganizationRequestFixtures.update("Conflicting Name Ltd");
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
-      when(repository.existsByLegalName(request.legalName())).thenReturn(true);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(existing));
+      when(organizationRepository.existsByLegalName(request.legalName())).thenReturn(true);
 
       assertThatThrownBy(() -> service.update(ORGANIZATION_ID, request))
           .isInstanceOf(DuplicateResourceException.class);
@@ -623,39 +641,39 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("should throw ResourceNotFoundException when org does not exist")
     void shouldThrowWhenOrgNotFound() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.empty());
 
       assertThatThrownBy(() -> service.updateLogoKey(ORGANIZATION_ID, "logos/new/logo"))
           .isInstanceOf(ResourceNotFoundException.class);
 
-      verify(repository, never()).save(any());
+      verify(organizationRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("should save new key and return null when no previous key")
+    @DisplayName("should publish new key and return null when no previous key")
     void shouldSaveNewKeyAndReturnNullWhenNoPreviousKey() {
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
-      when(repository.save(organization)).thenReturn(organization);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(organizationRepository.save(organization)).thenReturn(organization);
 
       String previous = service.updateLogoKey(ORGANIZATION_ID, "logos/new/logo");
 
       assertThat(previous).isNull();
-      verify(repository).save(organization);
+      verify(organizationRepository).save(organization);
     }
 
     @Test
-    @DisplayName("should save new key and return previous key when one existed")
+    @DisplayName("should publish new key and return previous key when one existed")
     void shouldSaveNewKeyAndReturnPreviousKey() {
       String existingKey = "logos/old/logo";
       ReflectionTestUtils.setField(organization, "logoKey", existingKey);
 
-      when(repository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
-      when(repository.save(organization)).thenReturn(organization);
+      when(organizationRepository.findById(ORGANIZATION_ID)).thenReturn(Optional.of(organization));
+      when(organizationRepository.save(organization)).thenReturn(organization);
 
       String previous = service.updateLogoKey(ORGANIZATION_ID, "logos/new/logo");
 
       assertThat(previous).isEqualTo(existingKey);
-      verify(repository).save(organization);
+      verify(organizationRepository).save(organization);
     }
   }
 }


### PR DESCRIPTION
## Purpose
Publishes an `ORGANIZATION_WELCOME` email notification when an organization is approved
and activated. Also publishes an `OrganizationCreatedEvent` to the outbox on approval.

## List of Changes
- Added `ORGANIZATIONS_ORGANIZATION_CREATED` routing key to `EventConstants.RoutingKeys`
- Removed `EventConstants.MessageHeaders` — moved to `ApplicationConstants.MessageHeaders`
- Renamed `OutboxService.save` to `publish` for consistency
- Added `NotificationRequest`, `ChannelType`, `NotificationCategory`, `NotificationProperties`
- Added `NotificationEventPublisher` and `NotificationMapper` (MapStruct)
- Added `NotificationService` delegating to mapper and publisher
- Updated `OrganizationService.recordCreateApproval` to invoke `notificationService.sendOrganizationWelcome`
  and publish `OrganizationCreatedEvent` via `OutboxService`
- Updated `AuditEventPublisher`, `MakerCheckerRequestPublisher`, `OutboxEventProcessor`
  for the `save` → `publish` rename
- Pinned Dockerfile base image digest and restricted COPY file permissions to `550`
- Updated all affected unit and integration tests

## Linked Issues
- #10 

## How to Test
1. Start the service with all dependencies via Docker Compose
2. Submit a `POST /organizations` request with valid payload and required documents
3. Approve the resulting maker-checker request via the checker service
4. Verify the outbox contains two new records:
   - `eventType = organizations.organization.approved` (audit)
   - `eventType = organizations.organization.created`, `routingKey = organizations.organization.created`
5. Verify a notification outbox record is queued with `routingKey = notifications.email`
6. Run `./mvnw test` — all unit and integration tests should pass

## Additional Information
- No database schema changes required
- `ORGANIZATION_WELCOME` template is already seeded in `notifications.templates`
- Template variables (`organizationName`, `logoUrl`, `organizationAddress`, `loginUrl`,
  `supportUrl`, `currentYear`) are resolved downstream by the notification service's
  `TemplateVariableEnricher` using `organizationId`
- `adminUsername` is resolved by the notification service via its IAM adapter using `subjectUserId`
- `NotificationProperties.enabled` flag controls whether notifications are queued;
  defaults to `true`