### PR TITLE
test(config): add notifications configurations to tests

### DIFF
--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -160,6 +160,9 @@ management:
       exposure:
         include: health,info,metrics,prometheus
 
+notifications:
+  enabled: false
+
 security:
   public-endpoints:
     - /actuator/health


### PR DESCRIPTION
## Purpose

Adds a `notifications.enabled` feature flag to `application.yaml`, allowing notification dispatch to be toggled off at the application level without a code change.

## List of Changes

- Added `notifications.enabled: false` to `application.yaml` under the `management` block and above the `security` block

## Linked Issues

N/A

## How to Test

1. Start the application with the default config
2. Trigger a notification event
3. Confirm no notifications are dispatched while `notifications.enabled` is `false`
4. Set `notifications.enabled: true` and repeat — notifications should dispatch normally

## Additional Information
- N/A