### PR TITLE
fix(spotbugs): exclude MapStruct-generated mapper

### DIFF
--- a/spotbugs/exclude-filter.xml
+++ b/spotbugs/exclude-filter.xml
@@ -78,4 +78,15 @@
         <Bug pattern="SE_BAD_FIELD"/>
     </Match>
 
+    <!--
+      NP_NULL_ON_SOME_PATH: excluded for MapStruct-generated mapper implementations.
+      SpotBugs flags null dereference paths introduced by MapStruct's defensive null
+      checks on source parameters. The parameter is annotated @NotNull and guaranteed
+      non-null at all call sites; the generated branches are unreachable in practice.
+    -->
+    <Match>
+        <Package name="~com\.ebikes\.organizations\.mappers"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH"/>
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
## Purpose

Suppresses a false-positive SpotBugs `NP_NULL_ON_SOME_PATH` warning produced by MapStruct-generated mapper implementations in the organizations service.

## List of Changes

- Added `NP_NULL_ON_SOME_PATH` exclusion to `spotbugs/exclude-filter.xml` scoped to `com.ebikes.organizations.mappers`, with a comment explaining the root cause

## Linked Issues

N/A

## How to Test

1. Run `mvn spotbugs:check` — build should pass with no SpotBugs errors
2. Confirm `NotificationMapperImpl.toOrganizationWelcome` is no longer flagged

## Additional Information

SpotBugs flags null dereference paths in the generated `NotificationMapperImpl` because MapStruct emits defensive null-check branches for source parameters. The `organization` parameter is annotated `@NotNull` and is guaranteed non-null at all call sites; the flagged paths are unreachable in practice. This is a known limitation of static analysis against generated code.