### PR TITLE
chore: update logging

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,7 +60,6 @@ spring:
         type:
           json_format_mapper: com.ebikes.organizations.configurations.HibernateJsonFormatMapperConfiguration
 
-
   liquibase:
     change-log: classpath:database/changelog/changelog-main.yaml
     enabled: true
@@ -125,14 +124,14 @@ document:
 logging:
   level:
     root: INFO
-    com.ebikes: DEBUG
+    com.ebikes.organizations: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
 
 management:
   endpoint:
     health:
-      show-details: ${ACTUATOR_HEALTH_DETAILS:always}
+      show-details: ${ACTUATOR_HEALTH_DETAILS:never}
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## Purpose

Refines application runtime configuration by narrowing DEBUG logging to the `com.ebikes.organizations` package and hardening actuator health endpoint exposure by default.

## List of Changes

* Scoped DEBUG logging from the broad `com.ebikes` namespace to `com.ebikes.organizations`.
* Changed `management.endpoint.health.show-details` default from `always` to `never`.
* Kept the setting environment-overridable through `ACTUATOR_HEALTH_DETAILS`.
* No schema, API contract, or business logic changes.

## Linked Issues

* N/A

## How to Test

1. Start the service normally.
2. Confirm application startup succeeds with the updated `application.yaml`.
3. Exercise application flows and verify DEBUG logs are emitted for `com.ebikes.organizations` classes only, instead of the broader `com.ebikes` namespace.
4. Call the actuator health endpoint and confirm detailed health information is hidden by default.
5. Set `ACTUATOR_HEALTH_DETAILS=always`, restart the service, and confirm health details are shown again.

## Additional Information
- N/A