### PR TITLE
fix(images): harden logo upload persistence with versioned S3 keys

### DIFF
--- a/src/main/java/com/ebikes/organizations/controllers/OrganizationController.java
+++ b/src/main/java/com/ebikes/organizations/controllers/OrganizationController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ebikes.organizations.database.entities.Organization;
-import com.ebikes.organizations.dtos.internal.UploadUrlData;
 import com.ebikes.organizations.dtos.requests.filters.OrganizationFilter;
 import com.ebikes.organizations.dtos.requests.organizations.CreateOrganizationRequest;
 import com.ebikes.organizations.dtos.requests.organizations.DeactivateOrganizationRequest;
@@ -32,6 +31,7 @@ import com.ebikes.organizations.dtos.responses.api.PaginatedResponse;
 import com.ebikes.organizations.dtos.responses.api.SuccessResponse;
 import com.ebikes.organizations.dtos.responses.documents.DocumentPreviewResponse;
 import com.ebikes.organizations.dtos.responses.documents.DocumentSummaryResponse;
+import com.ebikes.organizations.dtos.responses.organizations.ImageUploadInitiationResponse;
 import com.ebikes.organizations.dtos.responses.organizations.OrganizationReference;
 import com.ebikes.organizations.dtos.responses.organizations.OrganizationResponse;
 import com.ebikes.organizations.dtos.responses.organizations.OrganizationSummaryResponse;
@@ -101,11 +101,11 @@ public class OrganizationController {
 
   @PreAuthorize("hasAnyAuthority('ORGANIZATION_ADMIN', 'SYSTEM_ADMIN')")
   @PostMapping("/{id}/logo/upload-url")
-  public ResponseEntity<SuccessResponse<UploadUrlData>> generateLogoUploadUrl(
+  public ResponseEntity<SuccessResponse<ImageUploadInitiationResponse>> generateLogoUploadUrl(
       @PathVariable UUID id) {
-    UploadUrlData uploadUrlData = imageService.generateImageUploadUrl(id);
+    ImageUploadInitiationResponse response = imageService.generateImageUploadUrl(id);
     return ResponseEntity.ok(
-        SuccessResponse.of(uploadUrlData, "Logo upload URL generated successfully"));
+        SuccessResponse.of(response, "Logo upload URL generated successfully"));
   }
 
   @PreAuthorize("hasAnyAuthority('ORGANIZATION_ADMIN', 'SYSTEM_ADMIN')")

--- a/src/main/java/com/ebikes/organizations/dtos/requests/organizations/ImageUploadConfirmationRequest.java
+++ b/src/main/java/com/ebikes/organizations/dtos/requests/organizations/ImageUploadConfirmationRequest.java
@@ -6,4 +6,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ImageUploadConfirmationRequest(
-    @NotNull @Min(value = 1) Long fileSizeBytes, @NotBlank @Size(max = 100) String mimeType) {}
+    @NotNull @Min(value = 1) Long fileSizeBytes,
+    @NotBlank @Size(max = 500) String logoKey,
+    @NotBlank @Size(max = 100) String mimeType) {}

--- a/src/main/java/com/ebikes/organizations/dtos/responses/organizations/ImageUploadInitiationResponse.java
+++ b/src/main/java/com/ebikes/organizations/dtos/responses/organizations/ImageUploadInitiationResponse.java
@@ -1,0 +1,8 @@
+package com.ebikes.organizations.dtos.responses.organizations;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ImageUploadInitiationResponse(
+    Instant expiryTime, String key, Map<String, List<String>> signedHeaders, String url) {}

--- a/src/main/java/com/ebikes/organizations/services/images/ImageService.java
+++ b/src/main/java/com/ebikes/organizations/services/images/ImageService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ebikes.organizations.dtos.internal.UploadUrlData;
 import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
+import com.ebikes.organizations.dtos.responses.organizations.ImageUploadInitiationResponse;
 import com.ebikes.organizations.enums.ResponseCode;
 import com.ebikes.organizations.exceptions.ValidationException;
 import com.ebikes.organizations.services.organizations.OrganizationService;
@@ -31,18 +32,20 @@ public class ImageService {
   private final OrganizationService organizationService;
   private final StorageService storageService;
 
-  public UploadUrlData generateImageUploadUrl(UUID organizationId) {
+  public ImageUploadInitiationResponse generateImageUploadUrl(UUID organizationId) {
     organizationService.requireById(organizationId);
     String key = buildImageKey(organizationId);
     log.info("Generating logo upload URL: organizationId={}, key={}", organizationId, key);
-    return storageService.generateUploadUrl(key, null, null, null);
+    UploadUrlData uploadUrlData = storageService.generateUploadUrl(key, null, null, null);
+    return new ImageUploadInitiationResponse(
+        uploadUrlData.expiryTime(), key, uploadUrlData.headers(), uploadUrlData.url());
   }
 
   @Transactional
   public void confirmImageUpload(UUID organizationId, ImageUploadConfirmationRequest request) {
     validateMimeType(request.mimeType());
 
-    String key = buildImageKey(organizationId);
+    String key = request.logoKey();
 
     var metadata = storageService.getStoredFileMetadata(key);
     if (!metadata.exists()) {
@@ -79,7 +82,7 @@ public class ImageService {
   }
 
   private String buildImageKey(UUID organizationId) {
-    return LOGO_KEY_PREFIX + organizationId + LOGO_KEY_SUFFIX;
+    return LOGO_KEY_PREFIX + organizationId + LOGO_KEY_SUFFIX + "-" + UUID.randomUUID();
   }
 
   private void validateMimeType(String mimeType) {

--- a/src/test/java/com/ebikes/organizations/controllers/OrganizationControllerTest.java
+++ b/src/test/java/com/ebikes/organizations/controllers/OrganizationControllerTest.java
@@ -27,8 +27,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.ebikes.organizations.dtos.internal.UploadUrlData;
 import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
+import com.ebikes.organizations.dtos.responses.organizations.ImageUploadInitiationResponse;
 import com.ebikes.organizations.enums.UserRole;
 import com.ebikes.organizations.mappers.OrganizationMapper;
 import com.ebikes.organizations.services.documents.DocumentService;
@@ -64,7 +64,7 @@ class OrganizationControllerTest extends AbstractControllerTest {
   class ConfirmLogoUpload {
 
     private ImageUploadConfirmationRequest validRequest() {
-      return new ImageUploadConfirmationRequest(102400L, "image/jpeg");
+      return new ImageUploadConfirmationRequest(102400L, "test-key", "image/jpeg");
     }
 
     @Test
@@ -395,10 +395,13 @@ class OrganizationControllerTest extends AbstractControllerTest {
     @Test
     @DisplayName("should return 200 when user is ORGANIZATION_ADMIN")
     void shouldReturn200WhenOrganizationAdmin() throws Exception {
-      UploadUrlData uploadUrlData =
-          new UploadUrlData(
-              "https://s3.example.com/upload", Map.of(), Instant.now().plusSeconds(3600));
-      when(imageService.generateImageUploadUrl(ORG_ID)).thenReturn(uploadUrlData);
+      ImageUploadInitiationResponse response =
+          new ImageUploadInitiationResponse(
+              Instant.now().plusSeconds(3600),
+              "test-key",
+              Map.of(),
+              "https://s3.example.com/upload");
+      when(imageService.generateImageUploadUrl(ORG_ID)).thenReturn(response);
 
       mockMvc
           .perform(
@@ -412,9 +415,12 @@ class OrganizationControllerTest extends AbstractControllerTest {
     @Test
     @DisplayName("should return 200 when user is SYSTEM_ADMIN")
     void shouldReturn200WhenSystemAdmin() throws Exception {
-      UploadUrlData uploadUrlData =
-          new UploadUrlData(
-              "https://s3.example.com/upload", Map.of(), Instant.now().plusSeconds(3600));
+      ImageUploadInitiationResponse uploadUrlData =
+          new ImageUploadInitiationResponse(
+              Instant.now().plusSeconds(3600),
+              "test-key",
+              Map.of(),
+              "https://s3.example.com/upload");
       when(imageService.generateImageUploadUrl(ORG_ID)).thenReturn(uploadUrlData);
 
       mockMvc

--- a/src/test/java/com/ebikes/organizations/services/images/ImageServiceTest.java
+++ b/src/test/java/com/ebikes/organizations/services/images/ImageServiceTest.java
@@ -23,6 +23,7 @@ import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.dtos.internal.StoredFileMetadata;
 import com.ebikes.organizations.dtos.internal.UploadUrlData;
 import com.ebikes.organizations.dtos.requests.organizations.ImageUploadConfirmationRequest;
+import com.ebikes.organizations.dtos.responses.organizations.ImageUploadInitiationResponse;
 import com.ebikes.organizations.exceptions.ValidationException;
 import com.ebikes.organizations.services.organizations.OrganizationService;
 import com.ebikes.organizations.services.storage.StorageService;
@@ -33,7 +34,7 @@ import com.ebikes.organizations.support.fixtures.OrganizationFixtures;
 class ImageServiceTest {
 
   private static final UUID ORG_ID = UUID.randomUUID();
-  private static final String EXPECTED_KEY = "logos/" + ORG_ID + "/logo";
+  private static final String STORED_LOGO_KEY = "logos/" + ORG_ID + "/logo-abc123";
 
   @Mock private OrganizationService organizationService;
   @Mock private StorageService storageService;
@@ -53,18 +54,19 @@ class ImageServiceTest {
   class GenerateImageUploadUrl {
 
     @Test
-    @DisplayName("should verify org exists, derive key, and delegate to storage service")
-    void shouldVerifyOrgAndDelegateToStorage() {
+    @DisplayName("should verify org exists, generate versioned key, and return initiation response")
+    void shouldVerifyOrgAndReturnInitiationResponse() {
       UploadUrlData uploadUrlData = new UploadUrlData("https://s3.example.com/upload", null, null);
       when(organizationService.requireById(ORG_ID)).thenReturn(organization);
-      when(storageService.generateUploadUrl(eq(EXPECTED_KEY), eq(null), eq(null), eq(null)))
+      when(storageService.generateUploadUrl(any(String.class), eq(null), eq(null), eq(null)))
           .thenReturn(uploadUrlData);
 
-      UploadUrlData result = service.generateImageUploadUrl(ORG_ID);
+      ImageUploadInitiationResponse response = service.generateImageUploadUrl(ORG_ID);
 
-      assertThat(result).isEqualTo(uploadUrlData);
       verify(organizationService).requireById(ORG_ID);
-      verify(storageService).generateUploadUrl(EXPECTED_KEY, null, null, null);
+      verify(storageService).generateUploadUrl(any(String.class), eq(null), eq(null), eq(null));
+      assertThat(response.key()).startsWith("logos/" + ORG_ID + "/logo-");
+      assertThat(response.url()).isEqualTo("https://s3.example.com/upload");
     }
   }
 
@@ -75,30 +77,32 @@ class ImageServiceTest {
     @Test
     @DisplayName("should confirm upload and skip deletion when no previous key")
     void shouldConfirmAndSkipDeletionWhenNoPreviousKey() {
+      String logoKey = "logos/" + ORG_ID + "/logo-new";
       ImageUploadConfirmationRequest request =
-          new ImageUploadConfirmationRequest(102400L, "image/jpeg");
+          new ImageUploadConfirmationRequest(102400L, logoKey, "image/jpeg");
       StoredFileMetadata metadata = new StoredFileMetadata(102400L, "image/jpeg", null, true);
 
-      when(storageService.getStoredFileMetadata(EXPECTED_KEY)).thenReturn(metadata);
-      when(organizationService.updateLogoKey(ORG_ID, EXPECTED_KEY)).thenReturn(null);
+      when(storageService.getStoredFileMetadata(logoKey)).thenReturn(metadata);
+      when(organizationService.updateLogoKey(ORG_ID, logoKey)).thenReturn(null);
 
       service.confirmImageUpload(ORG_ID, request);
 
-      verify(storageService).getStoredFileMetadata(EXPECTED_KEY);
-      verify(organizationService).updateLogoKey(ORG_ID, EXPECTED_KEY);
+      verify(storageService).getStoredFileMetadata(logoKey);
+      verify(organizationService).updateLogoKey(ORG_ID, logoKey);
       verify(storageService, never()).deleteObject(any());
     }
 
     @Test
     @DisplayName("should confirm upload and delete previous key when one exists")
     void shouldConfirmAndDeletePreviousKeyWhenPresent() {
+      String logoKey = "logos/" + ORG_ID + "/logo-new";
       String previousKey = "logos/" + ORG_ID + "/logo-old";
       ImageUploadConfirmationRequest request =
-          new ImageUploadConfirmationRequest(102400L, "image/png");
+          new ImageUploadConfirmationRequest(102400L, logoKey, "image/png");
       StoredFileMetadata metadata = new StoredFileMetadata(102400L, "image/png", null, true);
 
-      when(storageService.getStoredFileMetadata(EXPECTED_KEY)).thenReturn(metadata);
-      when(organizationService.updateLogoKey(ORG_ID, EXPECTED_KEY)).thenReturn(previousKey);
+      when(storageService.getStoredFileMetadata(logoKey)).thenReturn(metadata);
+      when(organizationService.updateLogoKey(ORG_ID, logoKey)).thenReturn(previousKey);
 
       service.confirmImageUpload(ORG_ID, request);
 
@@ -109,7 +113,7 @@ class ImageServiceTest {
     @DisplayName("should throw ValidationException when mime type is not allowed")
     void shouldThrowWhenMimeTypeNotAllowed() {
       ImageUploadConfirmationRequest request =
-          new ImageUploadConfirmationRequest(102400L, "image/gif");
+          new ImageUploadConfirmationRequest(102400L, "logos/" + ORG_ID + "/logo-new", "image/gif");
 
       assertThatThrownBy(() -> service.confirmImageUpload(ORG_ID, request))
           .isInstanceOf(ValidationException.class);
@@ -121,11 +125,12 @@ class ImageServiceTest {
     @Test
     @DisplayName("should throw ValidationException when file not found in storage")
     void shouldThrowWhenFileNotFoundInStorage() {
+      String logoKey = "logos/" + ORG_ID + "/logo-new";
       ImageUploadConfirmationRequest request =
-          new ImageUploadConfirmationRequest(102400L, "image/webp");
+          new ImageUploadConfirmationRequest(102400L, logoKey, "image/webp");
       StoredFileMetadata metadata = new StoredFileMetadata(null, null, null, false);
 
-      when(storageService.getStoredFileMetadata(EXPECTED_KEY)).thenReturn(metadata);
+      when(storageService.getStoredFileMetadata(logoKey)).thenReturn(metadata);
 
       assertThatThrownBy(() -> service.confirmImageUpload(ORG_ID, request))
           .isInstanceOf(ValidationException.class);
@@ -142,15 +147,15 @@ class ImageServiceTest {
     @DisplayName("should return presigned URL when org has a logo key")
     void shouldReturnPresignedUrlWhenLogoKeyPresent() {
       String presignedUrl = "https://s3.example.com/logos/presigned";
-      ReflectionTestUtils.setField(organization, "logoKey", EXPECTED_KEY);
+      ReflectionTestUtils.setField(organization, "logoKey", STORED_LOGO_KEY);
 
       when(organizationService.requireById(ORG_ID)).thenReturn(organization);
-      when(storageService.generatePreviewUrl(eq(EXPECTED_KEY), any())).thenReturn(presignedUrl);
+      when(storageService.generatePreviewUrl(eq(STORED_LOGO_KEY), any())).thenReturn(presignedUrl);
 
       String result = service.generateImageRedirectUrl(ORG_ID);
 
       assertThat(result).isEqualTo(presignedUrl);
-      verify(storageService).generatePreviewUrl(eq(EXPECTED_KEY), any());
+      verify(storageService).generatePreviewUrl(eq(STORED_LOGO_KEY), any());
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Fixes a bug in the logo upload pipeline where the persisted S3 object was immediately  deleted after a successful upload. The root cause was that `buildImageKey` always produced the same deterministic key, causing `previousKey == newKey` on every re-upload, which triggered deletion of the just-confirmed object.

## List of Changes
- Introduced versioned S3 key generation in `ImageService` — each upload now produces a unique key of the form `logos/{orgId}/logo-{uuid}`, ensuring the confirmed key can never equal the previous key.
- Extracted `ImageUploadInitiationResponse` as a dedicated API response DTO, replacing the internal `UploadUrlData` record as the return type of `generateImageUploadUrl`. The response now includes the generated `key` so the client can echo it back on confirmation.
- Added `logoKey` field to `ImageUploadConfirmationRequest` — the server no longer reconstructs the key on confirmation; it uses the key supplied by the client, which must match what was uploaded.
- `UploadUrlData` remains unchanged — it is an internal transfer object used across both document and image upload flows.

## Linked Issues
- Fixes #(logo upload 404 after successful PUT)

## How to Test
1. Start LocalStack S3 via `docker compose -f localstack-s3.yml up -d`
2. Run the application with the local environment variables set
3. Call `POST /organizations/{id}/logo/upload-url` — verify the response includes both `url` and `key` fields
4. PUT the image file directly to the presigned `url`
5. Call `PUT /organizations/{id}/logo` with `logoKey` set to the `key` from step 3
6. Call `GET /organizations/{id}/logo` — verify a `302` redirect to a valid presigned GET URL is returned and the image loads successfully
7. Repeat steps 3–6 to confirm the previous object is deleted and the new one is accessible — LocalStack logs should show `PutObject 200`, `HeadObject 200`, `DeleteObject 204` on the old key, and `GetObject 200` on the new key

## Additional Information
- No database migrations required — the `logo_key` column already supports keys up to 500 characters, which accommodates the UUID suffix.
- The frontend must be updated in the same release to pass `logoKey` in the confirmation request body and to update the `ImageUploadInitiationResponse` and `ImageUploadConfirmationRequest` TypeScript interfaces accordingly.