### PR TITLE
fix(organizations): wire compliance check

### DIFF
--- a/src/main/java/com/ebikes/organizations/constants/EventConstants.java
+++ b/src/main/java/com/ebikes/organizations/constants/EventConstants.java
@@ -65,6 +65,8 @@ public final class EventConstants {
       public static final String DEACTIVATED = Source.ORGANIZATIONS + ".organization.deactivated";
       public static final String REJECTED = Source.ORGANIZATIONS + ".organization.rejected";
       public static final String UPDATED = Source.ORGANIZATIONS + ".organization.updated";
+      public static final String WELCOME_EMAIL_DISPATCHED =
+          Source.ORGANIZATIONS + ".organization.welcome-email-dispatched";
     }
   }
 

--- a/src/main/java/com/ebikes/organizations/controllers/DocumentController.java
+++ b/src/main/java/com/ebikes/organizations/controllers/DocumentController.java
@@ -25,7 +25,9 @@ import com.ebikes.organizations.enums.DocumentType;
 import com.ebikes.organizations.services.documents.DocumentService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/documents")
 @RestController
@@ -40,7 +42,7 @@ public class DocumentController {
         documentService.initiateUpload(
             request.documentType(),
             request.fileName(),
-            request.contentType(),
+            request.templateContentType(),
             request.expiryDate());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.of(response, "Upload initiated successfully."));
@@ -71,7 +73,7 @@ public class DocumentController {
       @PathVariable UUID id, @Valid @RequestBody DocumentUploadInitiationRequest request) {
     DocumentUploadInitiationResponse response =
         documentService.replaceDocument(
-            id, request.fileName(), request.contentType(), request.expiryDate());
+            id, request.fileName(), request.templateContentType(), request.expiryDate());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.of(response, "Document replacement initiated"));
   }

--- a/src/main/java/com/ebikes/organizations/dtos/requests/documents/DocumentUploadInitiationRequest.java
+++ b/src/main/java/com/ebikes/organizations/dtos/requests/documents/DocumentUploadInitiationRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
 import com.ebikes.organizations.enums.DocumentType;
 
 public record DocumentUploadInitiationRequest(
-    @NotBlank String contentType,
+    @NotBlank String templateContentType,
     @NotNull DocumentType documentType,
     @Future LocalDate expiryDate,
     @NotBlank @Size(max = 255, message = "File name must not exceed 255 characters") String fileName) {}

--- a/src/main/java/com/ebikes/organizations/mappers/EventMapper.java
+++ b/src/main/java/com/ebikes/organizations/mappers/EventMapper.java
@@ -13,6 +13,7 @@ import com.ebikes.organizations.dtos.events.outgoing.OrganizationCreatedEvent;
 public interface EventMapper {
   @Mapping(target = "displayName", source = "organization.displayName")
   @Mapping(target = "organizationId", source = "organization.id")
+  @Mapping(target = "ownerId", source = "organization.ownerId")
   @Mapping(target = "serviceReference", source = "serviceReference")
   OrganizationCreatedEvent toOrganizationCreatedEvent(
       Organization organization, String serviceReference);

--- a/src/main/java/com/ebikes/organizations/mappers/NotificationMapper.java
+++ b/src/main/java/com/ebikes/organizations/mappers/NotificationMapper.java
@@ -3,6 +3,7 @@ package com.ebikes.organizations.mappers;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import com.ebikes.organizations.constants.EventConstants;
 import com.ebikes.organizations.database.entities.Organization;
 import com.ebikes.organizations.dtos.events.outgoing.NotificationRequest;
 
@@ -12,7 +13,9 @@ public interface NotificationMapper {
   @Mapping(target = "branchId", ignore = true)
   @Mapping(target = "category", constant = "OPERATIONAL")
   @Mapping(target = "channel", constant = "EMAIL")
-  @Mapping(target = "eventType", constant = "ORGANIZATION_WELCOME")
+  @Mapping(
+      target = "eventType",
+      constant = EventConstants.DomainEvents.Organization.WELCOME_EMAIL_DISPATCHED)
   @Mapping(target = "organizationId", expression = "java(organization.getId().toString())")
   @Mapping(target = "recipient", source = "organization.email")
   @Mapping(target = "serviceReference", source = "serviceReference")

--- a/src/main/java/com/ebikes/organizations/services/branches/BranchAddressService.java
+++ b/src/main/java/com/ebikes/organizations/services/branches/BranchAddressService.java
@@ -55,6 +55,7 @@ public class BranchAddressService {
             .branch(branch)
             .city(organizationAddress.city())
             .country(organizationAddress.country())
+            .createdBy(branch.getCreatedBy())
             .latitude(organizationAddress.latitude())
             .longitude(organizationAddress.longitude())
             .postalCode(organizationAddress.postalCode())

--- a/src/main/java/com/ebikes/organizations/services/branches/BranchService.java
+++ b/src/main/java/com/ebikes/organizations/services/branches/BranchService.java
@@ -89,6 +89,7 @@ public class BranchService {
     Branch branch =
         Branch.builder()
             .branchName("MAIN")
+            .createdBy(organization.getCreatedBy())
             .displayName(organization.getDisplayName() + " - Main Branch")
             .email(organization.getEmail())
             .operatingHours(List.of())

--- a/src/main/java/com/ebikes/organizations/services/documents/DocumentService.java
+++ b/src/main/java/com/ebikes/organizations/services/documents/DocumentService.java
@@ -471,7 +471,7 @@ public class DocumentService {
           String.format(
               "Content type %s not allowed for %s. Allowed types: %s",
               contentType, documentType, allowedContentTypes),
-          "contentType",
+          "templateContentType",
           contentType);
     }
   }

--- a/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
+++ b/src/main/java/com/ebikes/organizations/services/organizations/OrganizationService.java
@@ -226,7 +226,6 @@ public class OrganizationService {
     return existing;
   }
 
-  @Transactional
   public void updateComplianceStatus(Organization organization) {
     boolean compliant =
         documentService.hasAllRequiredDocumentsActive(
@@ -278,6 +277,7 @@ public class OrganizationService {
             () -> repository.save(organization));
 
     branchService.createDefaultBranch(approved);
+    updateComplianceStatus(approved);
     notificationService.sendOrganizationWelcome(approved);
     outboxService.publish(
         DomainEvents.Organization.CREATED,


### PR DESCRIPTION
## Purpose

Fixes several gaps in the organisation approval flow: `ownerId` was missing from the
`OrganizationCreatedEvent`, compliance status was not evaluated post-approval, the default branch
and its address were missing `createdBy`, and the document upload field `contentType` conflicted
with a reserved name.

## List of Changes

- Added `WELCOME_EMAIL_DISPATCHED` constant to `EventConstants.DomainEvents.Organization` and
  updated `NotificationMapper` to use it in place of the inline `"ORGANIZATION_WELCOME"` literal
- Added `ownerId` mapping to `EventMapper.toOrganizationCreatedEvent()`
- Called `updateComplianceStatus(approved)` after `createDefaultBranch()` in `OrganizationService`
  and removed stale `@Transactional` from `updateComplianceStatus()` — always called within an
  existing transaction
- Set `createdBy` on the default `Branch` from `organization.getCreatedBy()` in `BranchService`
- Set `createdBy` on `BranchAddress` from `branch.getCreatedBy()` in `BranchAddressService`
- Renamed `contentType` to `templateContentType` in `DocumentUploadInitiationRequest`, both
  `DocumentController` call sites, and the validation error field in `DocumentService`

## Linked Issues

N/A

## How to Test

1. Approve an organisation and verify:
   - `OrganizationCreatedEvent` contains a non-null `ownerId`
   - Default branch and its address have `createdBy` populated
   - Organisation `compliant` flag reflects active document state immediately after approval
2. Submit a document upload request via `POST /documents` and `PUT /documents/{id}` with
   `templateContentType` and confirm validation errors reference `templateContentType`
3. Confirm the notification is dispatched with
   `eventType = organizations.organization.welcome-email-dispatched`

## Additional Information

- `templateContentType` rename is a **breaking API change** — clients must update their payloads
- `updateComplianceStatus` no longer owns its own transaction; must be called within a transactional context